### PR TITLE
Replaced String(utf8String: value) with String(cString: value)

### DIFF
--- a/Sources/MockServer/main.swift
+++ b/Sources/MockServer/main.swift
@@ -170,7 +170,7 @@ func env(_ name: String) -> String? {
     guard let value = getenv(name) else {
         return nil
     }
-    return String(utf8String: value)
+    return String(cString: value)
 }
 
 // main

--- a/Sources/SwiftAwsLambda/Utils.swift
+++ b/Sources/SwiftAwsLambda/Utils.swift
@@ -39,7 +39,7 @@ internal func env(_ name: String) -> String? {
     guard let value = getenv(name) else {
         return nil
     }
-    return String(utf8String: value)
+    return String(cString: value)
 }
 
 /// Helper function to trap signals


### PR DESCRIPTION
String(utf8String: UnsafePointer) is a Foundation API.
Replaced with Swift STL equivalent.