### PR TITLE
LambdaRuntimeClient works with Invocation

### DIFF
--- a/Sources/MockServer/main.swift
+++ b/Sources/MockServer/main.swift
@@ -108,7 +108,12 @@ internal final class HTTPHandler: ChannelInboundHandler {
             case .json:
                 responseBody = "{ \"body\": \"\(requestId)\" }"
             }
-            responseHeaders = [(AmazonHeaders.requestID, requestId)]
+            responseHeaders = [
+                (AmazonHeaders.requestID, requestId),
+                (AmazonHeaders.invokedFunctionARN, "arn:aws:lambda:us-east-1:123456789012:function:custom-runtime"),
+                (AmazonHeaders.traceID, "Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1"),
+                (AmazonHeaders.deadline, String(Date(timeIntervalSinceNow: 60).timeIntervalSince1970 * 1000)),
+            ]
         } else if request.head.uri.hasSuffix("/response") {
             responseStatus = .accepted
         } else {

--- a/Sources/SwiftAwsLambda/Lambda+Codable.swift
+++ b/Sources/SwiftAwsLambda/Lambda+Codable.swift
@@ -50,7 +50,7 @@ public typealias LambdaCodableCallback<Out> = (LambdaCodableResult<Out>) -> Void
 
 /// A processing closure for a Lambda that takes an `In` and returns an `Out` via `LambdaCodableCallback<Out>` asynchronously,
 /// having `In` and `Out` extending `Decodable` and `Encodable` respectively.
-public typealias LambdaCodableClosure<In, Out> = (LambdaContext, In, LambdaCodableCallback<Out>) -> Void
+public typealias LambdaCodableClosure<In, Out> = (Lambda.Context, In, LambdaCodableCallback<Out>) -> Void
 
 /// A processing protocol for a Lambda that takes an `In` and returns an `Out` via `LambdaCodableCallback<Out>` asynchronously,
 /// having `In` and `Out` extending `Decodable` and `Encodable` respectively.
@@ -58,7 +58,7 @@ public protocol LambdaCodableHandler: LambdaHandler {
     associatedtype In: Decodable
     associatedtype Out: Encodable
 
-    func handle(context: LambdaContext, payload: In, callback: @escaping LambdaCodableCallback<Out>)
+    func handle(context: Lambda.Context, payload: In, callback: @escaping LambdaCodableCallback<Out>)
     var codec: LambdaCodableCodec<In, Out> { get }
 }
 
@@ -79,7 +79,7 @@ public class LambdaCodableCodec<In: Decodable, Out: Encodable> {
 
 /// Default implementation of `Encodable` -> `[UInt8]` encoding and `[UInt8]` -> `Decodable' decoding
 public extension LambdaCodableHandler {
-    func handle(context: LambdaContext, payload: [UInt8], callback: @escaping (LambdaResult) -> Void) {
+    func handle(context: Lambda.Context, payload: [UInt8], callback: @escaping (LambdaResult) -> Void) {
         switch self.codec.decode(payload) {
         case .failure(let error):
             return callback(.failure(Errors.requestDecoding(error)))
@@ -133,7 +133,7 @@ private struct LambdaClosureWrapper<In: Decodable, Out: Encodable>: LambdaCodabl
         self.closure = closure
     }
 
-    public func handle(context: LambdaContext, payload: In, callback: @escaping LambdaCodableCallback<Out>) {
+    public func handle(context: Lambda.Context, payload: In, callback: @escaping LambdaCodableCallback<Out>) {
         self.closure(context, payload, callback)
     }
 }

--- a/Sources/SwiftAwsLambda/Lambda+String.swift
+++ b/Sources/SwiftAwsLambda/Lambda+String.swift
@@ -46,16 +46,16 @@ public typealias LambdaStringResult = Result<String, Error>
 public typealias LambdaStringCallback = (LambdaStringResult) -> Void
 
 /// A processing closure for a Lambda that takes a `String` and returns a `LambdaStringResult` via `LambdaStringCallback` asynchronously.
-public typealias LambdaStringClosure = (LambdaContext, String, LambdaStringCallback) -> Void
+public typealias LambdaStringClosure = (Lambda.Context, String, LambdaStringCallback) -> Void
 
 /// A processing protocol for a Lambda that takes a `String` and returns a `LambdaStringResult` via `LambdaStringCallback` asynchronously.
 public protocol LambdaStringHandler: LambdaHandler {
-    func handle(context: LambdaContext, payload: String, callback: @escaping LambdaStringCallback)
+    func handle(context: Lambda.Context, payload: String, callback: @escaping LambdaStringCallback)
 }
 
 /// Default implementation of `String` -> `[UInt8]` encoding and `[UInt8]` -> `String' decoding
 public extension LambdaStringHandler {
-    func handle(context: LambdaContext, payload: [UInt8], callback: @escaping LambdaCallback) {
+    func handle(context: Lambda.Context, payload: [UInt8], callback: @escaping LambdaCallback) {
         self.handle(context: context, payload: String(decoding: payload, as: UTF8.self)) { result in
             switch result {
             case .success(let string):
@@ -73,7 +73,7 @@ private struct LambdaClosureWrapper: LambdaStringHandler {
         self.closure = closure
     }
 
-    func handle(context: LambdaContext, payload: String, callback: @escaping LambdaStringCallback) {
+    func handle(context: Lambda.Context, payload: String, callback: @escaping LambdaStringCallback) {
         self.closure(context, payload, callback)
     }
 }

--- a/Tests/SwiftAwsLambdaTests/Lambda+CodeableTest.swift
+++ b/Tests/SwiftAwsLambdaTests/Lambda+CodeableTest.swift
@@ -150,7 +150,7 @@ private struct Response: Codable {
 }
 
 private struct CodableEchoHandler: LambdaCodableHandler {
-    func handle(context: LambdaContext, payload: Request, callback: @escaping LambdaCodableCallback<Response>) {
+    func handle(context: Lambda.Context, payload: Request, callback: @escaping LambdaCodableCallback<Response>) {
         callback(.success(Response(requestId: payload.requestId)))
     }
 }

--- a/Tests/SwiftAwsLambdaTests/Lambda+StringTest.swift
+++ b/Tests/SwiftAwsLambdaTests/Lambda+StringTest.swift
@@ -120,7 +120,7 @@ private struct BadBehavior: LambdaServerBehavior {
 }
 
 private struct StringEchoHandler: LambdaStringHandler {
-    func handle(context: LambdaContext, payload: String, callback: @escaping LambdaStringCallback) {
+    func handle(context: Lambda.Context, payload: String, callback: @escaping LambdaStringCallback) {
         callback(.success(payload))
     }
 }

--- a/Tests/SwiftAwsLambdaTests/LambdaRuntimeClientTest+XCTest.swift
+++ b/Tests/SwiftAwsLambdaTests/LambdaRuntimeClientTest+XCTest.swift
@@ -27,7 +27,7 @@ extension LambdaRuntimeClientTest {
         return [
             ("testGetWorkServerInternalError", testGetWorkServerInternalError),
             ("testGetWorkServerNoBodyError", testGetWorkServerNoBodyError),
-            ("testGetWorkServerNoContextError", testGetWorkServerNoContextError),
+            ("testGetWorkServerMissingHeaderRequestIDError", testGetWorkServerMissingHeaderRequestIDError),
             ("testProcessResponseInternalServerError", testProcessResponseInternalServerError),
             ("testProcessErrorInternalServerError", testProcessErrorInternalServerError),
             ("testProcessInitErrorInternalServerError", testProcessInitErrorInternalServerError),

--- a/Tests/SwiftAwsLambdaTests/LambdaRuntimeClientTest.swift
+++ b/Tests/SwiftAwsLambdaTests/LambdaRuntimeClientTest.swift
@@ -68,7 +68,7 @@ class LambdaRuntimeClientTest: XCTestCase {
         }
     }
 
-    func testGetWorkServerNoContextError() throws {
+    func testGetWorkServerMissingHeaderRequestIDError() throws {
         struct Behavior: LambdaServerBehavior {
             func getWork() -> GetWorkResult {
                 // no request id -> no context
@@ -91,7 +91,7 @@ class LambdaRuntimeClientTest: XCTestCase {
             }
         }
         XCTAssertThrowsError(try runLambda(behavior: Behavior(), handler: EchoHandler())) { error in
-            XCTAssertEqual(error as? LambdaRuntimeClientError, LambdaRuntimeClientError.noContext)
+            XCTAssertEqual(error as? LambdaRuntimeClientError, LambdaRuntimeClientError.invocationMissingHeader(AmazonHeaders.requestID))
         }
     }
 

--- a/Tests/SwiftAwsLambdaTests/LambdaTest.swift
+++ b/Tests/SwiftAwsLambdaTests/LambdaTest.swift
@@ -86,7 +86,7 @@ class LambdaTest: XCTestCase {
     func testStartStop() throws {
         let server = try MockLambdaServer(behavior: GoodBehavior()).start().wait()
         struct MyHandler: LambdaHandler {
-            func handle(context: LambdaContext, payload: [UInt8], callback: @escaping LambdaCallback) {
+            func handle(context: Lambda.Context, payload: [UInt8], callback: @escaping LambdaCallback) {
                 callback(.success(payload))
             }
         }

--- a/Tests/SwiftAwsLambdaTests/MockLambdaServer.swift
+++ b/Tests/SwiftAwsLambdaTests/MockLambdaServer.swift
@@ -140,7 +140,12 @@ internal final class HTTPHandler: ChannelInboundHandler {
                 }
                 responseStatus = .ok
                 responseBody = result
-                responseHeaders = [(AmazonHeaders.requestID, requestId)]
+                responseHeaders = [
+                    (AmazonHeaders.requestID, requestId),
+                    (AmazonHeaders.invokedFunctionARN, "arn:aws:lambda:us-east-1:123456789012:function:custom-runtime"),
+                    (AmazonHeaders.traceID, "Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1"),
+                    (AmazonHeaders.deadline, String(Date(timeIntervalSinceNow: 60).timeIntervalSince1970 * 1000)),
+                ]
             case .failure(let error):
                 responseStatus = .init(statusCode: error.rawValue)
             }

--- a/Tests/SwiftAwsLambdaTests/Utils.swift
+++ b/Tests/SwiftAwsLambdaTests/Utils.swift
@@ -38,7 +38,7 @@ final class EchoHandler: LambdaHandler {
         callback(.success(()))
     }
 
-    func handle(context: LambdaContext, payload: [UInt8], callback: @escaping LambdaCallback) {
+    func handle(context: Lambda.Context, payload: [UInt8], callback: @escaping LambdaCallback) {
         callback(.success(payload))
     }
 }
@@ -50,7 +50,7 @@ struct FailedHandler: LambdaHandler {
         self.reason = reason
     }
 
-    func handle(context: LambdaContext, payload: [UInt8], callback: @escaping LambdaCallback) {
+    func handle(context: Lambda.Context, payload: [UInt8], callback: @escaping LambdaCallback) {
         callback(.failure(Error(description: self.reason)))
     }
 
@@ -66,7 +66,7 @@ struct FailedInitializerHandler: LambdaHandler {
         self.reason = reason
     }
 
-    func handle(context: LambdaContext, payload: [UInt8], callback: @escaping LambdaCallback) {
+    func handle(context: Lambda.Context, payload: [UInt8], callback: @escaping LambdaCallback) {
         callback(.success(payload))
     }
 


### PR DESCRIPTION
### Motivation:

- We want to store different entities that are needed when executing a handler within the `LambdaContext` (`Logger`, `EventLoop`, `ByteBufferAllocator`, …)
- Currently the `LambdaRuntimeClient` creates the LambdaContext. Having the `LambdaContext` with the `Logger`, `EventLoop` and `ByteBufferAllocator` be created from the `LambdaRuntimeClient` feels too much for me.
- Conceptionally the Lambda control plane api call is “get next Invocation” (API naming)

### Changes:

- LambdaRuntimeClient responds with an Invocation and does not use the LambdaContext at all anymore.
- `LambdaRunner` creates the `LambdaContext` with the `Invocation` and `Logger` (easy to add `EventLoop` and `ByteBufferAllocator` – not for this PR).
- `LambdaContext` has been renamed to `Lambda.Context`
- `Lambda.Context` has become a class, since it is conceptually not a value type and might be passed around a lot
- `Lambda.Context` properties `traceId`, `invokedFunctionArn`, `deadline` are not optional anymore since they will be always set when executing a lambda
- Creating an `Invocation` can fail with `LambdaRuntimeClientError.invocationMissingHeader(String)`, if non optional headers are not present
- the test `MockLambdaServer` and the performance test `MockServer` always return headers for deadline, traceId and function arn (static for now – could be changed with Behaviour flag – new PR?). This leads to decreased performance in performance tests, but is probably closer to real life behaviour.

### Open ends:

- we will need to build some kind of Deadline into the context (See also #9 - probably for a different PR)
- we have a stupid mapping between `ByteBuffer` and `[UInt8]` in the `LambdaRunner` for now (marked with two TODOs). I don’t want to change this in this PR since it will lead to huge merge conflicts down the road with the potentiall API changes we have in mind.