### PR TITLE
Send “Connection” headers only when keepAlive == false

### DIFF
--- a/Sources/MockServer/main.swift
+++ b/Sources/MockServer/main.swift
@@ -125,7 +125,10 @@ internal final class HTTPHandler: ChannelInboundHandler {
     func writeResponse(context: ChannelHandlerContext, status: HTTPResponseStatus, headers: [(String, String)]? = nil, body: String? = nil) {
         var headers = HTTPHeaders(headers ?? [])
         headers.add(name: "Content-Length", value: "\(body?.utf8.count ?? 0)")
-        headers.add(name: "Connection", value: self.keepAlive ? "keep-alive" : "close")
+        if !self.keepAlive {
+            // We only need to add a "Connection" header if we really want to close the connection
+            headers.add(name: "Connection", value: "close")
+        }
         let head = HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: status, headers: headers)
 
         context.write(wrapOutboundOut(.head(head))).whenFailure { error in


### PR DESCRIPTION
### Motivation

- after some investigation I discovered that the lambda control plane, does not expect a request header `"Connection" = "keep-alive"` and does not send a response header `"Connection" = "keep-alive"`
- http/1.1 specifies in RFC 2616, Section 8.1.2:

> [...] unless otherwise indicated, the client SHOULD assume that the server will maintain a persistent connection, even after error responses from the server.

Further, for the response it defines:

>  An HTTP/1.1 client MAY expect a connection to remain open, but would decide to keep it open based on whether the response from a server contains a Connection header with the connection-token close. In case the client does not want to maintain a connection for more than that request, it SHOULD send a Connection header including the connection-token close.

- since we have been expecting `"Connection" = "keep-alive"` in the response until now, we where tearing down our connection after every request

### Changes

- We only send the `"Connection" = "close"` header if we don't want to keep the connection alive.
- The `MockServer` does send the `"Connection" = "close"` header only if it want's to close the connection
- We check if the response is HTTP/1.1 to close the connection otherwise.