### PR TITLE
rename project to SwiftAWSLambdaRuntime

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,22 +1,22 @@
 # Code of Conduct
-To be a truly great community, SwiftAwsLambda needs to welcome developers from all walks of life,
+To be a truly great community, SwiftAWSLambdaRuntime needs to welcome developers from all walks of life,
 with different backgrounds, and with a wide range of experience. A diverse and friendly
-community will have more great ideas, more unique perspectives, and produce more great 
-code. We will work diligently to make the SwiftAwsLambda community welcoming to everyone.
+community will have more great ideas, more unique perspectives, and produce more great
+code. We will work diligently to make the SwiftAWSLambdaRuntime community welcoming to everyone.
 
-To give clarity of what is expected of our members, SwiftAwsLambda has adopted the code of conduct 
-defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source 
+To give clarity of what is expected of our members, SwiftAWSLambdaRuntime has adopted the code of conduct
+defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source
 communities, and we think it articulates our values well. The full text is copied below:
 
 ### Contributor Code of Conduct v1.3
-As contributors and maintainers of this project, and in the interest of fostering an open and 
-welcoming community, we pledge to respect all people who contribute through reporting 
-issues, posting feature requests, updating documentation, submitting pull requests or patches, 
+As contributors and maintainers of this project, and in the interest of fostering an open and
+welcoming community, we pledge to respect all people who contribute through reporting
+issues, posting feature requests, updating documentation, submitting pull requests or patches,
 and other activities.
 
-We are committed to making participation in this project a harassment-free experience for 
-everyone, regardless of level of experience, gender, gender identity and expression, sexual 
-orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or 
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression, sexual
+orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or
 nationality.
 
 Examples of unacceptable behavior by participants include:
@@ -27,29 +27,29 @@ Examples of unacceptable behavior by participants include:
 - Publishing other’s private information, such as physical or electronic addresses, without explicit permission
 - Other unethical or unprofessional conduct
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, 
-commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of 
-Conduct, or to ban temporarily or permanently any contributor for other behaviors that they 
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of
+Conduct, or to ban temporarily or permanently any contributor for other behaviors that they
 deem inappropriate, threatening, offensive, or harmful.
 
-By adopting this Code of Conduct, project maintainers commit themselves to fairly and 
-consistently applying these principles to every aspect of managing this project. Project 
-maintainers who do not follow or enforce the Code of Conduct may be permanently removed 
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and
+consistently applying these principles to every aspect of managing this project. Project
+maintainers who do not follow or enforce the Code of Conduct may be permanently removed
 from the project team.
 
-This code of conduct applies both within project spaces and in public spaces when an 
+This code of conduct applies both within project spaces and in public spaces when an
 individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
-contacting a project maintainer at [swift-server-conduct@group.apple.com](mailto:swift-server-conduct@group.apple.com). All complaints will be reviewed and 
-investigated and will result in a response that is deemed necessary and appropriate to the 
-circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter 
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+contacting a project maintainer at [swift-server-conduct@group.apple.com](mailto:swift-server-conduct@group.apple.com). All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and appropriate to the
+circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter
 of an incident.
 
 *This policy is adapted from the Contributor Code of Conduct [version 1.3.0](https://contributor-covenant.org/version/1/3/0/).*
 
 ### Reporting
 A working group of community members is committed to promptly addressing any [reported issues](mailto:swift-server-conduct@group.apple.com).
-Working group members are volunteers appointed by the project lead, with a 
-preference for individuals with varied backgrounds and perspectives. Membership is expected 
+Working group members are volunteers appointed by the project lead, with a
+preference for individuals with varied backgrounds and perspectives. Membership is expected
 to change regularly, and may grow or shrink.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ that your contributions are licensed under the Apache 2.0 license (see
 
 Please ensure to specify the following:
 
-* SwiftAwsLambda commit hash
-* Contextual information (e.g. what you were trying to achieve with SwiftAwsLambda)
+* SwiftAWSLambdaRuntime commit hash
+* Contextual information (e.g. what you were trying to achieve with SwiftAWSLambdaRuntime)
 * Simplest possible steps to reproduce
   * More complex the steps are, lower the priority will be.
   * A pull request with failing test case is preferred, but it's just fine to paste the test case into the issue description.
@@ -24,10 +24,10 @@ Please ensure to specify the following:
 ### Example
 
 ```
-SwiftAwsLambda commit hash: 22ec043dc9d24bb011b47ece4f9ee97ee5be2757
+SwiftAWSLambdaRuntime commit hash: 22ec043dc9d24bb011b47ece4f9ee97ee5be2757
 
 Context:
-While load testing my HTTP web server written with SwiftAwsLambda, I noticed
+While load testing my Lambda written with SwiftAWSLambdaRuntime, I noticed
 that one file descriptor is leaked per request.
 
 Steps to reproduce:
@@ -50,7 +50,7 @@ My system has IPv6 disabled.
 
 ## Writing a Patch
 
-A good SwiftAwsLambda patch is:
+A good SwiftAWSLambdaRuntime patch is:
 
 1. Concise, and contains as few changes as needed to achieve the end result.
 2. Tested, ensuring that any tests provided failed before the patch and pass after it.
@@ -62,11 +62,6 @@ A good SwiftAwsLambda patch is:
 We require that your commit messages match our template. The easiest way to do that is to get git to help you by explicitly using the template. To do that, `cd` to the root of our repository and run:
 
     git config commit.template dev/git.commit.template
-
-### Make sure Tests work on Linux
-
-SwiftAwsLambda uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not. 
-For this reason, whenever you add new tests **you have to run a script** that generates the hooks needed to run those tests on Linux, or our CI will complain that the tests are not all present on Linux. To do this, merely execute `ruby ./scripts/generate_linux_tests.rb` at the root of the package and check the changes it made.
 
 ## How to contribute your work
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,5 +1,5 @@
 For the purpose of tracking copyright, this is the list of individuals and
-organizations who have contributed source code to SwiftAwsLambda.
+organizations who have contributed source code to SwiftAWSLambdaRuntime.
 
 For employees of an organization/company where the copyright of work done
 by employees of that company is held by the company itself, only the company

--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,9 @@
 import PackageDescription
 
 let package = Package(
-    name: "swift-aws-lambda",
+    name: "swift-aws-lambda-runtime",
     products: [
-        .library(name: "SwiftAwsLambda", targets: ["SwiftAwsLambda"]),
+        .library(name: "AWSLambdaRuntime", targets: ["AWSLambdaRuntime"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.8.0"),
@@ -13,16 +13,16 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.0"),
     ],
     targets: [
-        .target(name: "SwiftAwsLambda", dependencies: [
+        .target(name: "AWSLambdaRuntime", dependencies: [
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),
         ]),
-        .testTarget(name: "SwiftAwsLambdaTests", dependencies: ["SwiftAwsLambda"]),
+        .testTarget(name: "AWSLambdaRuntimeTests", dependencies: ["AWSLambdaRuntime"]),
         // samples
-        .target(name: "SwiftAwsLambdaStringSample", dependencies: ["SwiftAwsLambda"]),
-        .target(name: "SwiftAwsLambdaCodableSample", dependencies: ["SwiftAwsLambda"]),
+        .target(name: "StringSample", dependencies: ["AWSLambdaRuntime"]),
+        .target(name: "CodableSample", dependencies: ["AWSLambdaRuntime"]),
         // perf tests
         .target(name: "MockServer", dependencies: [
             .product(name: "NIOHTTP1", package: "swift-nio"),

--- a/Sources/AWSLambdaRuntime/HttpClient.swift
+++ b/Sources/AWSLambdaRuntime/HttpClient.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/Lambda+Codable.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+Codable.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+String.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/LambdaConfiguration.swift
+++ b/Sources/AWSLambdaRuntime/LambdaConfiguration.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntime/LambdaContext.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntime/LambdaHandler.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/LambdaLifecycle.swift
+++ b/Sources/AWSLambdaRuntime/LambdaLifecycle.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRunner.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntimeClient.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/AWSLambdaRuntime/Utils.swift
+++ b/Sources/AWSLambdaRuntime/Utils.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/CodableSample/main.swift
+++ b/Sources/CodableSample/main.swift
@@ -1,19 +1,19 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
 
+import AWSLambdaRuntime
 import NIO
-import SwiftAwsLambda
 
 struct Request: Codable {
     let body: String

--- a/Sources/MockServer/main.swift
+++ b/Sources/MockServer/main.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/StringSample/main.swift
+++ b/Sources/StringSample/main.swift
@@ -1,19 +1,19 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
 
+import AWSLambdaRuntime
 import NIO
-import SwiftAwsLambda
 
 // in this example we are receiving and responding with strings
 struct Handler: EventLoopLambdaHandler {

--- a/Tests/AWSLambdaRuntimeTests/Lambda+StringTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+StringTest.swift
@@ -1,33 +1,33 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
 
+@testable import AWSLambdaRuntime
 import NIO
-@testable import SwiftAwsLambda
 import XCTest
 
-class CodableLambdaTest: XCTestCase {
+class StringLambdaTest: XCTestCase {
     func testCallbackSuccess() {
         let server = MockLambdaServer(behavior: Behavior())
         XCTAssertNoThrow(try server.start().wait())
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias In = Request
-            typealias Out = Response
+            typealias In = String
+            typealias Out = String
 
-            func handle(context: Lambda.Context, payload: Request, callback: (Result<Response, Error>) -> Void) {
-                callback(.success(Response(requestId: payload.requestId)))
+            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
+                callback(.success(payload))
             }
         }
 
@@ -43,10 +43,10 @@ class CodableLambdaTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias In = Request
+            typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, payload: Request, callback: (Result<Void, Error>) -> Void) {
+            func handle(context: Lambda.Context, payload: String, callback: (Result<Void, Error>) -> Void) {
                 callback(.success(()))
             }
         }
@@ -63,10 +63,10 @@ class CodableLambdaTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias In = Request
-            typealias Out = Response
+            typealias In = String
+            typealias Out = String
 
-            func handle(context: Lambda.Context, payload: Request, callback: (Result<Response, Error>) -> Void) {
+            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
                 callback(.failure(TestError("boom")))
             }
         }
@@ -83,11 +83,11 @@ class CodableLambdaTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias In = Request
-            typealias Out = Response
+            typealias In = String
+            typealias Out = String
 
-            func handle(context: Lambda.Context, payload: Request) -> EventLoopFuture<Response> {
-                context.eventLoop.makeSucceededFuture(Response(requestId: payload.requestId))
+            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
+                context.eventLoop.makeSucceededFuture(payload)
             }
         }
 
@@ -103,10 +103,10 @@ class CodableLambdaTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias In = Request
+            typealias In = String
             typealias Out = Void
 
-            func handle(context: Lambda.Context, payload: Request) -> EventLoopFuture<Void> {
+            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<Void> {
                 context.eventLoop.makeSucceededFuture(())
             }
         }
@@ -123,10 +123,10 @@ class CodableLambdaTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: EventLoopLambdaHandler {
-            typealias In = Request
-            typealias Out = Response
+            typealias In = String
+            typealias Out = String
 
-            func handle(context: Lambda.Context, payload: Request) -> EventLoopFuture<Response> {
+            func handle(context: Lambda.Context, payload: String) -> EventLoopFuture<String> {
                 context.eventLoop.makeFailedFuture(TestError("boom"))
             }
         }
@@ -144,8 +144,8 @@ class CodableLambdaTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration) { (_, payload: Request, callback) in
-            callback(.success(Response(requestId: payload.requestId)))
+        let result = Lambda.run(configuration: configuration) { (_, payload: String, callback) in
+            callback(.success(payload))
         }
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
     }
@@ -157,7 +157,7 @@ class CodableLambdaTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result = Lambda.run(configuration: configuration) { (_, _: Request, callback: (Result<Void, Error>) -> Void) in
+        let result = Lambda.run(configuration: configuration) { (_, _: String, callback) in
             callback(.success(()))
         }
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
@@ -170,7 +170,7 @@ class CodableLambdaTest: XCTestCase {
 
         let maxTimes = Int.random(in: 1 ... 10)
         let configuration = Lambda.Configuration(lifecycle: .init(maxTimes: maxTimes))
-        let result: Result<Int, Error> = Lambda.run(configuration: configuration) { (_, _: Request, callback: (Result<Response, Error>) -> Void) in
+        let result: Result<Int, Error> = Lambda.run(configuration: configuration) { (_, _: String, callback: (Result<String, Error>) -> Void) in
             callback(.failure(TestError("boom")))
         }
         assertLambdaLifecycleResult(result, shoudHaveRun: maxTimes)
@@ -182,14 +182,14 @@ class CodableLambdaTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Handler: LambdaHandler {
-            typealias In = Request
-            typealias Out = Response
+            typealias In = String
+            typealias Out = String
 
             init(eventLoop: EventLoop) throws {
                 throw TestError("kaboom")
             }
 
-            func handle(context: Lambda.Context, payload: Request, callback: (Result<Response, Error>) -> Void) {
+            func handle(context: Lambda.Context, payload: String, callback: (Result<String, Error>) -> Void) {
                 callback(.failure(TestError("should not be called")))
             }
         }
@@ -199,7 +199,6 @@ class CodableLambdaTest: XCTestCase {
     }
 }
 
-// TODO: taking advantage of the fact we know the serialization is json
 private struct Behavior: LambdaServerBehavior {
     let requestId: String
     let payload: String
@@ -212,38 +211,18 @@ private struct Behavior: LambdaServerBehavior {
     }
 
     func getWork() -> GetWorkResult {
-        guard let payload = try? JSONEncoder().encode(Request(requestId: requestId)) else {
-            XCTFail("encoding error")
-            return .failure(.internalServerError)
-        }
-        guard let payloadAsString = String(data: payload, encoding: .utf8) else {
-            XCTFail("encoding error")
-            return .failure(.internalServerError)
-        }
-        return .success((requestId: self.requestId, payload: payloadAsString))
+        .success((requestId: self.requestId, payload: self.payload))
     }
 
     func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError> {
+        XCTAssertEqual(self.requestId, requestId, "expecting requestId to match")
         switch self.result {
-        case .success(let expected) where expected != nil:
-            guard let data = response?.data(using: .utf8) else {
-                XCTFail("decoding error")
-                return .failure(.internalServerError)
-            }
-            guard let response = try? JSONDecoder().decode(Response.self, from: data) else {
-                XCTFail("decoding error")
-                return .failure(.internalServerError)
-            }
-            XCTAssertEqual(self.requestId, response.requestId, "expecting requestId to match")
-            return .success(())
-        case .success(let expected) where expected == nil:
-            XCTAssertNil(response)
+        case .success(let expected):
+            XCTAssertEqual(expected, response, "expecting response to match")
             return .success(())
         case .failure:
             XCTFail("unexpected to fail, but succeeded with: \(response ?? "undefined")")
             return .failure(.internalServerError)
-        default:
-            preconditionFailure("invalid state")
         }
     }
 
@@ -262,19 +241,5 @@ private struct Behavior: LambdaServerBehavior {
     func processInitError(error: ErrorResponse) -> Result<Void, ProcessErrorError> {
         XCTFail("should not report init error")
         return .failure(.internalServerError)
-    }
-}
-
-private struct Request: Codable {
-    let requestId: String
-    init(requestId: String) {
-        self.requestId = requestId
-    }
-}
-
-private struct Response: Codable {
-    let requestId: String
-    init(requestId: String) {
-        self.requestId = requestId
     }
 }

--- a/Tests/AWSLambdaRuntimeTests/LambdaRunnerTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRunnerTest.swift
@@ -1,18 +1,18 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SwiftAwsLambda
+@testable import AWSLambdaRuntime
 import XCTest
 
 class LambdaRunnerTest: XCTestCase {

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeClientTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeClientTest.swift
@@ -1,18 +1,18 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SwiftAwsLambda
+@testable import AWSLambdaRuntime
 import XCTest
 
 class LambdaRuntimeClientTest: XCTestCase {

--- a/Tests/AWSLambdaRuntimeTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaTest.swift
@@ -1,20 +1,20 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
 
+@testable import AWSLambdaRuntime
 import Logging
 import NIO
-@testable import SwiftAwsLambda
 import XCTest
 
 class LambdaTest: XCTestCase {

--- a/Tests/AWSLambdaRuntimeTests/MockLambdaServer.swift
+++ b/Tests/AWSLambdaRuntimeTests/MockLambdaServer.swift
@@ -1,22 +1,22 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
 
+@testable import AWSLambdaRuntime
 import Foundation // for JSON
 import Logging
 import NIO
 import NIOHTTP1
-@testable import SwiftAwsLambda
 
 internal final class MockLambdaServer {
     private let logger = Logger(label: "MockLambdaServer")

--- a/Tests/AWSLambdaRuntimeTests/Utils.swift
+++ b/Tests/AWSLambdaRuntimeTests/Utils.swift
@@ -1,20 +1,20 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
 
+@testable import AWSLambdaRuntime
 import Logging
 import NIO
-@testable import SwiftAwsLambda
 import XCTest
 
 func runLambda(behavior: LambdaServerBehavior, handler: ByteBufferLambdaHandler) throws {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) 2017-2020 Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) 2017-2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/readme.md
+++ b/readme.md
@@ -1,34 +1,39 @@
-# Swift AWS Lambda
+# SwiftAWSLambdaRuntime
 
-This library is designed to simplify implementing an AWS Lambda using the Swift programming language.
+SwiftAWSLambdaRuntime is a Swift implementation of [AWS Lambda Runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html).
+AWS Lambda runtime is a program that runs a Lambda function's handler method when the function is invoked.
+SwiftAWSLambdaRuntime is designed to simplify the implementation of an AWS Lambda using the Swift programming language.
 
 ## Getting started
 
-1. Create a SwiftPM project and pull SwiftAwsLambda as dependency into your project
+1. Create a SwiftPM project and pull SwiftAWSLambdaRuntime as dependency into your project
 
 ```swift
 // swift-tools-version:5.2
+
 import PackageDescription
 
 let package = Package(
-name: "my-lambda",
-products: [
-    .executable(name: "MyLambda", targets: ["MyLambda"]),
-],
-dependencies: [
-    .package(url: "https://github.com/swift-server/swift-aws-lambda.git", from: "0.1.0"),
-],
-targets: [
-    .target(name: "MyLambda", dependencies: ["SwiftAwsLambda"]),
-]
+    name: "my-lambda",
+    products: [
+        .executable(name: "MyLambda", targets: ["MyLambda"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", .branch("master")),
+    ],
+    targets: [
+        .target(name: "MyLambda", dependencies: [
+          .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda"),
+        ]),
+    ]
 )
 ```
 
-2. Create a main.swift and implement your Lambda. Typically a Lambda is implemented as a closure. 
+2. Create a main.swift and implement your Lambda. Typically a Lambda is implemented as a closure.
     For example, a closure that receives a string payload and replies with the reverse version:
 
 ```swift
-import SwiftAwsLambda
+import AWSLambdaRuntime
 
 // in this example we are receiving and responding with strings
 Lambda.run { (context, payload: String, callback) in
@@ -39,49 +44,51 @@ Lambda.run { (context, payload: String, callback) in
 Or more typically, a closure that receives a JSON payload and replies with a JSON response via `Codable`:
 
 ```swift
+import AWSLambdaRuntime
+
 private struct Request: Codable {}
 private struct Response: Codable {}
 
 // in this example we are receiving and responding with codables. Request and Response above are examples of how to use
-// codables to model your reqeuest and response objects
+// codables to model your request and response objects
 Lambda.run { (_, _: Request, callback) in
   callback(.success(Response()))
 }
 ```
 
-See a complete example in SwiftAwsLambdaSample.
+See a complete example in AWSLambdaRuntimeSample.
 
-3. Deploy to AWS Lambda. To do so, you need to compile your Application for Amazon 2 Linux, package it as a Zip file, and upload to AWS. 
-    You can find sample build and deployment scripts in SwiftAwsLambdaSample.
+3. Deploy to AWS Lambda. To do so, you need to compile your Application for Amazon 2 Linux, package it as a Zip file, and upload to AWS.
+    You can find sample build and deployment scripts in AWSLambdaRuntimeSample.
 
 ## Architecture
 
 The library defined 3 base protcols for the implementation of a Lambda:
 
 1. `ByteBufferLambdaHandler`: `EventLoopFuture` based processing protocol for a Lambda that takes a `ByteBuffer` and returns a `ByteBuffer?` asynchronously.
-    
+
     `ByteBufferLambdaHandler` is a low level protocol designed to power the higher level `EventLoopLambdaHandler` and `LambdaHandler` based APIs.
-    
+
     Most users are not expected to use this protocol.
 
 2. `EventLoopLambdaHandler`: Strongly typed, `EventLoopFuture` based processing protocol for a Lambda that takes a user defined `In` and returns a user defined `Out` asynchronously.
-    
+
     `EventLoopLambdaHandler` extends `ByteBufferLambdaHandler`, performing `ByteBuffer` -> `In` decoding and `Out` -> `ByteBuffer` encoding.
-    
+
     `EventLoopLambdaHandler` executes the Lambda on the same `EventLoop` as the core runtime engine, making the processing faster but requires more care from the implementation to never block the `EventLoop`.
 
 3. `LambdaHandler`: Strongly typed, callback based processing protocol for a Lambda that takes a user defined `In` and returns a user defined `Out` asynchronously.
-    
+
     `LambdaHandler` extends `ByteBufferLambdaHandler`, performing `ByteBuffer` -> `In` decoding and `Out` -> `ByteBuffer` encoding.
-    
+
     `LambdaHandler` offloads the Lambda execution to a `DispatchQueue` making processing safer but slower.
 
-In addition to protocol based Lambda, the library provides support for Closure based ones, as demosrated in the getting started section. 
-Closure based Lambda are based on the `LambdaHandler` protocol which mean the are safer but slower. 
-For most use cases, Closure based Lambda is a great fit. 
+In addition to protocol based Lambda, the library provides support for Closure based ones, as demosrated in the getting started section.
+Closure based Lambda are based on the `LambdaHandler` protocol which mean the are safer but slower.
+For most use cases, Closure based Lambda is a great fit.
 Only performance sensitive use cases should explore the `EventLoopLambdaHandler` protocol based approach as it requires more care from the implementation to never block the `EventLoop`.
 
-The library includes built-in codec for `String` and `Codable` into `ByteBuffer`, which means users can express `String` and `Codable` based Lambda without the need to provide encoding and decoding logic. 
+The library includes built-in codec for `String` and `Codable` into `ByteBuffer`, which means users can express `String` and `Codable` based Lambda without the need to provide encoding and decoding logic.
 Since AWS Lambda is primarily JSON based, this covers the most common use cases.
 The design does allow for other payload types as well, and such Lambda implementaion can extend one of the above protocols and provided their own `ByteBuffer` -> `In` decoding and `Out` -> `ByteBuffer` encoding.
 
@@ -98,14 +105,14 @@ The library encapsulates these endpoints and the expected lifecycle via `Lambda.
 
 1. The library calls AWS Lambda Runtime Engine `/next` endpoint to retrieve the next invocation request.
 2. The library parses the response HTTP headers and populate the `Lambda.Context` object.
-3. The library reads the response body and attempt to decode it, if required. 
+3. The library reads the response body and attempt to decode it, if required.
     Typically it decodes to user provided type which extends `Decodable`, but users may choose to write Lambdas that receive the input as `String` or `ByteBuffer` which require less, or no decoding.
-4. The library hands off the `Context` and `Request` to the user provided handler. 
+4. The library hands off the `Context` and `Request` to the user provided handler.
     In the case of `LambdaHandler` based Lambda this is done on a dedicated `DispatchQueue`, providing isolation between user's and the library's code.
 5. User's code processes the request asynchronously, invoking a callback or returning a future upon completion, which returns a result type with the `Response` or `Error` populated.
 6. In case of error, the library posts to AWS Lambda Runtime Engine `/error` endpoint to provide the error details, which will show up on AWS Lambda logs.
-7. In case of success, the library will attempt to encode the response, if required. 
-    Typically it encodes from user provided type which extends `Encodable`, but users may choose to write Lambdas that return a `String` or `ByteBuffer`, which require less, or no encoding. 
+7. In case of success, the library will attempt to encode the response, if required.
+    Typically it encodes from user provided type which extends `Encodable`, but users may choose to write Lambdas that return a `String` or `ByteBuffer`, which require less, or no encoding.
      The library then posts to AWS Lambda Runtime Engine `/response` endpoint to provide the response.
 
 **Lifecycle Management**

--- a/scripts/generate_contributors_list.sh
+++ b/scripts/generate_contributors_list.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftAwsLambda open source project
+## This source file is part of the SwiftAWSLambdaRuntime open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+## See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -19,7 +19,7 @@ contributors=$( cd "$here"/.. && git shortlog -es | cut -f2 | sed 's/^/- /' )
 
 cat > "$here/../CONTRIBUTORS.txt" <<- EOF
 	For the purpose of tracking copyright, this is the list of individuals and
-	organizations who have contributed source code to SwiftAwsLambda.
+	organizations who have contributed source code to AWSLambdaRuntime.
 
 	For employees of an organization/company where the copyright of work done
 	by employees of that company is held by the company itself, only the company

--- a/scripts/linux_performance_setup.sh
+++ b/scripts/linux_performance_setup.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftAwsLambda open source project
+## This source file is part of the SwiftAWSLambdaRuntime open source project
 ##
-## Copyright (c) 2020 Apple Inc. and the SwiftAwsLambda project authors
+## Copyright (c) 2020 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+## See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -37,10 +37,10 @@ cd -
 #
 # strace
 # export MAX_REQUESTS=10000
-# strace -o .build/strace-c-string-$MAX_REQUESTS -c .build/release/SwiftAwsLambdaStringSample
-# strace -o .build/strace-ffftt-string-$MAX_REQUESTS -fftt .build/release/SwiftAwsLambdaStringSample
+# strace -o .build/strace-c-string-$MAX_REQUESTS -c .build/release/StringSample
+# strace -o .build/strace-ffftt-string-$MAX_REQUESTS -fftt .build/release/StringSample
 #
 # perf
 # export MAX_REQUESTS=10000
-# perf record -o .build/perf-$MAX_REQUESTS.data -g .build/release/SwiftAwsLambdaStringSample dwarf
+# perf record -o .build/perf-$MAX_REQUESTS.data -g .build/release/StringSample dwarf
 # perf script -i .build/perf-$MAX_REQUESTS.data | /opt/FlameGraph/stackcollapse-perf.pl | swift-demangle | /opt/FlameGraph/flamegraph.pl > .build/flamegraph-$MAX_REQUESTS.svg

--- a/scripts/performance_test.sh
+++ b/scripts/performance_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftAwsLambda open source project
+## This source file is part of the SwiftAWSLambdaRuntime open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+## See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -58,7 +58,7 @@ cold=()
 export MAX_REQUESTS=1
 for (( i=0; i<$cold_iterations; i++ )); do
   start=$(gdate +%s%N)
-  ./.build/release/SwiftAwsLambdaStringSample
+  ./.build/release/StringSample
   end=$(gdate +%s%N)
   cold+=( $(($end-$start)) )
 done
@@ -70,7 +70,7 @@ results+=( "$MODE, cold: $avg_cold (ns)" )
 echo "running $MODE mode warm test"
 export MAX_REQUESTS=$warm_iterations
 start=$(gdate +%s%N)
-./.build/release/SwiftAwsLambdaStringSample
+./.build/release/StringSample
 end=$(gdate +%s%N)
 sum_warm=$(($end-$start-$avg_cold)) # substract by avg cold since the first call is cold
 avg_warm=$(($sum_warm/($warm_iterations-1))) # substract since the first call is cold
@@ -96,7 +96,7 @@ cold=()
 export MAX_REQUESTS=1
 for (( i=0; i<$cold_iterations; i++ )); do
   start=$(gdate +%s%N)
-  ./.build/release/SwiftAwsLambdaCodableSample
+  ./.build/release/CodableSample
   end=$(gdate +%s%N)
   cold+=( $(($end-$start)) )
 done
@@ -108,7 +108,7 @@ results+=( "$MODE, cold: $avg_cold (ns)" )
 echo "running $MODE mode warm test"
 export MAX_REQUESTS=$warm_iterations
 start=$(gdate +%s%N)
-./.build/release/SwiftAwsLambdaCodableSample
+./.build/release/CodableSample
 end=$(gdate +%s%N)
 sum_warm=$(($end-$start-$avg_cold)) # substract by avg cold since the first call is cold
 avg_warm=$(($sum_warm/($warm_iterations-1))) # substract since the first call is cold

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftAwsLambda open source project
+## This source file is part of the SwiftAWSLambdaRuntime open source project
 ##
-## Copyright (c) 2017-2018 Apple Inc. and the SwiftAwsLambda project authors
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftAWSLambdaRuntime project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+## See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -50,13 +50,13 @@ for language in swift-or-c bash dtrace; do
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftAwsLambda open source project
+// This source file is part of the SwiftAWSLambdaRuntime open source project
 //
-// Copyright (c) YEARS Apple Inc. and the SwiftAwsLambda project authors
+// Copyright (c) YEARS Apple Inc. and the SwiftAWSLambdaRuntime project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -69,13 +69,13 @@ EOF
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the SwiftAwsLambda open source project
+## This source file is part of the SwiftAWSLambdaRuntime open source project
 ##
-## Copyright (c) YEARS Apple Inc. and the SwiftAwsLambda project authors
+## Copyright (c) YEARS Apple Inc. and the SwiftAWSLambdaRuntime project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
-## See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+## See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ##
@@ -88,13 +88,13 @@ EOF
 #!/usr/sbin/dtrace -q -s
 /*===----------------------------------------------------------------------===*
  *
- *  This source file is part of the SwiftAwsLambda open source project
+ *  This source file is part of the SwiftAWSLambdaRuntime open source project
  *
- *  Copyright (c) YEARS Apple Inc. and the SwiftAwsLambda project authors
+ *  Copyright (c) YEARS Apple Inc. and the SwiftAWSLambdaRuntime project authors
  *  Licensed under Apache License v2.0
  *
  *  See LICENSE.txt for license information
- *  See CONTRIBUTORS.txt for the list of SwiftAwsLambda project authors
+ *  See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
  *
  *  SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
motivation: unique, accurate name

changes:
* rename project to SwiftAWSLambdaRuntime
* rename main module to AWSLambdaRuntime
* rename / simplify sample module names
* adjust readme and scripts