### PR TITLE
Reusable JSONCoders

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda+String.swift
+++ b/Sources/AWSLambdaRuntime/Lambda+String.swift
@@ -78,15 +78,8 @@ internal struct StringVoidLambdaClosureWrapper: LambdaHandler {
     }
 }
 
-/// Implementation of  a`ByteBuffer` to `String` and `String` to `ByteBuffer` codec
-public extension EventLoopLambdaHandler where In == String, Out == String {
-    func encode(allocator: ByteBufferAllocator, value: String) throws -> ByteBuffer? {
-        // FIXME: reusable buffer
-        var buffer = allocator.buffer(capacity: value.utf8.count)
-        buffer.writeString(value)
-        return buffer
-    }
-
+/// Implementation of  a`ByteBuffer` to `String` encoding
+public extension EventLoopLambdaHandler where In == String {
     func decode(buffer: ByteBuffer) throws -> String {
         var buffer = buffer
         guard let string = buffer.readString(length: buffer.readableBytes) else {
@@ -96,16 +89,12 @@ public extension EventLoopLambdaHandler where In == String, Out == String {
     }
 }
 
-public extension EventLoopLambdaHandler where In == String, Out == Void {
-    func encode(allocator: ByteBufferAllocator, value: Void) throws -> ByteBuffer? {
-        nil
-    }
-
-    func decode(buffer: ByteBuffer) throws -> String {
-        var buffer = buffer
-        guard let string = buffer.readString(length: buffer.readableBytes) else {
-            fatalError("buffer.readString(length: buffer.readableBytes) failed")
-        }
-        return string
+/// Implementation of  `String` to `ByteBuffer` decoding
+public extension EventLoopLambdaHandler where Out == String {
+    func encode(allocator: ByteBufferAllocator, value: String) throws -> ByteBuffer? {
+        // FIXME: reusable buffer
+        var buffer = allocator.buffer(capacity: value.utf8.count)
+        buffer.writeString(value)
+        return buffer
     }
 }

--- a/Sources/AWSLambdaRuntime/LambdaHandler.swift
+++ b/Sources/AWSLambdaRuntime/LambdaHandler.swift
@@ -107,6 +107,13 @@ public extension EventLoopLambdaHandler {
     }
 }
 
+/// Implementation of  `ByteBuffer` to `Void` decoding
+public extension EventLoopLambdaHandler where Out == Void {
+    func encode(allocator: ByteBufferAllocator, value: Void) throws -> ByteBuffer? {
+        nil
+    }
+}
+
 // MARK: - ByteBufferLambdaHandler
 
 /// An `EventLoopFuture` based processing protocol for a Lambda that takes a `ByteBuffer` and returns a `ByteBuffer?` asynchronously.


### PR DESCRIPTION
### Motivation

This shall fix #36. JSONCoders should be reused during multiple invocations, thus improving performance.

### Changes

- Introduced protocols (`LambdaCodableDecoder` and `LambdaCodableEncoder`)
- `JSONEncoder` conforms to `LambdaCodableEncoder`
- `JSONDecoder` conforms to `LambdaCodableDecoder`
- Added properties `encoder` and `decoder` on conditional conformances (In == Decodable and Out == Encodable) of `EventLoopLambdaHandler`
- Added private static `defaultJSONEncoder` and `defaultJSONDecoder` on Lambda to be used as default implementations.