### PR TITLE
AWSRegion without enum

### DIFF
--- a/Sources/AWSLambdaEvents/AWSRegion.swift
+++ b/Sources/AWSLambdaEvents/AWSRegion.swift
@@ -16,31 +16,77 @@
 //   $ aws ssm get-parameters-by-path --path /aws/service/global-infrastructure/services/lambda/regions --output json
 
 /// Enumeration of the AWS Regions.
-public enum AWSRegion: String, Codable {
-    case ap_northeast_1 = "ap-northeast-1"
-    case ap_northeast_2 = "ap-northeast-2"
-    case ap_east_1 = "ap-east-1"
-    case ap_southeast_1 = "ap-southeast-1"
-    case ap_southeast_2 = "ap-southeast-2"
-    case ap_south_1 = "ap-south-1"
+public struct AWSRegion: RawRepresentable, Equatable {
+    public typealias RawValue = String
 
-    case cn_north_1 = "cn-north-1"
-    case cn_northwest_1 = "cn-northwest-1"
+    public let rawValue: String
 
-    case eu_north_1 = "eu-north-1"
-    case eu_west_1 = "eu-west-1"
-    case eu_west_2 = "eu-west-2"
-    case eu_west_3 = "eu-west-3"
-    case eu_central_1 = "eu-central-1"
+    public init?(rawValue: String) {
+        self.rawValue = rawValue
+    }
 
-    case us_east_1 = "us-east-1"
-    case us_east_2 = "us-east-2"
-    case us_west_1 = "us-west-1"
-    case us_west_2 = "us-west-2"
-    case us_gov_east_1 = "us-gov-east-1"
-    case us_gov_west_1 = "us-gov-west-1"
+    static var all: [AWSRegion] = [
+        Self.ap_northeast_1,
+        Self.ap_northeast_2,
+        Self.ap_east_1,
+        Self.ap_southeast_1,
+        Self.ap_southeast_2,
+        Self.ap_south_1,
+        Self.cn_north_1,
+        Self.cn_northwest_1,
+        Self.eu_north_1,
+        Self.eu_west_1,
+        Self.eu_west_2,
+        Self.eu_west_3,
+        Self.eu_central_1,
+        Self.us_east_1,
+        Self.us_east_2,
+        Self.us_west_1,
+        Self.us_west_2,
+        Self.us_gov_east_1,
+        Self.us_gov_west_1,
+        Self.ca_central_1,
+        Self.sa_east_1,
+        Self.me_south_1,
+    ]
 
-    case ca_central_1 = "ca-central-1"
-    case sa_east_1 = "sa-east-1"
-    case me_south_1 = "me-south-1"
+    public static var ap_northeast_1: Self { AWSRegion(rawValue: "ap-northeast-1")! }
+    public static var ap_northeast_2: Self { AWSRegion(rawValue: "ap-northeast-2")! }
+    public static var ap_east_1: Self { AWSRegion(rawValue: "ap-east-1")! }
+    public static var ap_southeast_1: Self { AWSRegion(rawValue: "ap-southeast-1")! }
+    public static var ap_southeast_2: Self { AWSRegion(rawValue: "ap-southeast-2")! }
+    public static var ap_south_1: Self { AWSRegion(rawValue: "ap-south-1")! }
+
+    public static var cn_north_1: Self { AWSRegion(rawValue: "cn-north-1")! }
+    public static var cn_northwest_1: Self { AWSRegion(rawValue: "cn-northwest-1")! }
+
+    public static var eu_north_1: Self { AWSRegion(rawValue: "eu-north-1")! }
+    public static var eu_west_1: Self { AWSRegion(rawValue: "eu-west-1")! }
+    public static var eu_west_2: Self { AWSRegion(rawValue: "eu-west-2")! }
+    public static var eu_west_3: Self { AWSRegion(rawValue: "eu-west-3")! }
+    public static var eu_central_1: Self { AWSRegion(rawValue: "eu-central-1")! }
+
+    public static var us_east_1: Self { AWSRegion(rawValue: "us-east-1")! }
+    public static var us_east_2: Self { AWSRegion(rawValue: "us-east-2")! }
+    public static var us_west_1: Self { AWSRegion(rawValue: "us-west-1")! }
+    public static var us_west_2: Self { AWSRegion(rawValue: "us-west-2")! }
+    public static var us_gov_east_1: Self { AWSRegion(rawValue: "us-gov-east-1")! }
+    public static var us_gov_west_1: Self { AWSRegion(rawValue: "us-gov-west-1")! }
+
+    public static var ca_central_1: Self { AWSRegion(rawValue: "ca-central-1")! }
+    public static var sa_east_1: Self { AWSRegion(rawValue: "sa-east-1")! }
+    public static var me_south_1: Self { AWSRegion(rawValue: "me-south-1")! }
+}
+
+extension AWSRegion: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let region = try container.decode(String.self)
+        self.init(rawValue: region)!
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
 }


### PR DESCRIPTION
### Motivation

We don't want to leak enums because we can't add cases without a major version release later on. AWSRegion currently is an enum, where the possibility of further cases in the future is relatively high.

### Changes

- `AWSRegion` has become a `RawRepresentable` struct
- `AWSRegion` conforms to `Equatable` and `Codable`