### PR TITLE
Make Lambda.env() -> String? public

### DIFF
--- a/Sources/AWSLambdaRuntimeCore/Lambda.swift
+++ b/Sources/AWSLambdaRuntimeCore/Lambda.swift
@@ -62,6 +62,14 @@ public enum Lambda {
         self.run(factory: factory)
     }
 
+    /// Utility to access/read environment variables
+    public static func env(_ name: String) -> String? {
+        guard let value = getenv(name) else {
+            return nil
+        }
+        return String(cString: value)
+    }
+
     // for testing and internal use
     @discardableResult
     internal static func run(configuration: Configuration = .init(), handler: Handler) -> Result<Int, Error> {

--- a/Sources/AWSLambdaRuntimeCore/Utils.swift
+++ b/Sources/AWSLambdaRuntimeCore/Utils.swift
@@ -36,14 +36,6 @@ internal enum AmazonHeaders {
     static let invokedFunctionARN = "Lambda-Runtime-Invoked-Function-Arn"
 }
 
-/// Utility to read environment variables
-internal func env(_ name: String) -> String? {
-    guard let value = getenv(name) else {
-        return nil
-    }
-    return String(cString: value)
-}
-
 /// Helper function to trap signals
 internal func trap(signal sig: Signal, handler: @escaping (Signal) -> Void) -> DispatchSourceSignal {
     let signalSource = DispatchSource.makeSignalSource(signal: sig.rawValue, queue: DispatchQueue.global())


### PR DESCRIPTION
### Motivation

Developers need to access environment variables quite often at Lambda startup. We want to save them from importing Foundation. 🙃

### Changes

This PR makes our internal access env func public.