### PR TITLE
Rename RequestWork to GetNextInvocation

### DIFF
--- a/Sources/AWSLambdaRuntime/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRunner.swift
@@ -45,13 +45,13 @@ extension Lambda {
 
         func run(logger: Logger, handler: Handler) -> EventLoopFuture<Void> {
             logger.debug("lambda invocation sequence starting")
-            // 1. request work from lambda runtime engine
-            return self.runtimeClient.requestWork(logger: logger).peekError { error in
-                logger.error("could not fetch work from lambda runtime engine: \(error)")
+            // 1. request invocation from lambda runtime engine
+            return self.runtimeClient.getNextInvocation(logger: logger).peekError { error in
+                logger.error("could not fetch invocation from lambda runtime engine: \(error)")
             }.flatMap { invocation, payload in
-                // 2. send work to handler
+                // 2. send invocation to handler
                 let context = Context(logger: logger, eventLoop: self.eventLoop, invocation: invocation)
-                logger.debug("sending work to lambda handler \(handler)")
+                logger.debug("sending invocation to lambda handler \(handler)")
                 return handler.handle(context: context, payload: payload)
                     .mapResult { result in
                         if case .failure(let error) = result {

--- a/Sources/AWSLambdaRuntime/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntimeClient.swift
@@ -32,9 +32,9 @@ extension Lambda {
             self.httpClient = HTTPClient(eventLoop: eventLoop, configuration: configuration)
         }
 
-        /// Requests work from the Runtime Engine.
-        func requestWork(logger: Logger) -> EventLoopFuture<(Invocation, ByteBuffer)> {
-            let url = Consts.invocationURLPrefix + Consts.requestWorkURLSuffix
+        /// Requests invocation from the control plane.
+        func getNextInvocation(logger: Logger) -> EventLoopFuture<(Invocation, ByteBuffer)> {
+            let url = Consts.invocationURLPrefix + Consts.getNextInvocationURLSuffix
             logger.debug("requesting work from lambda runtime engine using \(url)")
             return self.httpClient.get(url: url).flatMapThrowing { response in
                 guard response.status == .ok else {

--- a/Sources/AWSLambdaRuntime/Utils.swift
+++ b/Sources/AWSLambdaRuntime/Utils.swift
@@ -18,7 +18,7 @@ import NIO
 internal enum Consts {
     private static let apiPrefix = "/2018-06-01"
     static let invocationURLPrefix = "\(apiPrefix)/runtime/invocation"
-    static let requestWorkURLSuffix = "/next"
+    static let getNextInvocationURLSuffix = "/next"
     static let postResponseURLSuffix = "/response"
     static let postErrorURLSuffix = "/error"
     static let postInitErrorURL = "\(apiPrefix)/runtime/init/error"

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -211,7 +211,7 @@ private struct Behavior: LambdaServerBehavior {
         self.result = result
     }
 
-    func getWork() -> GetWorkResult {
+    func getInvocation() -> GetInvocationResult {
         guard let payload = try? JSONEncoder().encode(Request(requestId: requestId)) else {
             XCTFail("encoding error")
             return .failure(.internalServerError)

--- a/Tests/AWSLambdaRuntimeTests/Lambda+StringTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+StringTest.swift
@@ -210,7 +210,7 @@ private struct Behavior: LambdaServerBehavior {
         self.result = result
     }
 
-    func getWork() -> GetWorkResult {
+    func getInvocation() -> GetInvocationResult {
         .success((requestId: self.requestId, payload: self.payload))
     }
 

--- a/Tests/AWSLambdaRuntimeTests/LambdaRunnerTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRunnerTest.swift
@@ -20,7 +20,7 @@ class LambdaRunnerTest: XCTestCase {
         struct Behavior: LambdaServerBehavior {
             let requestId = UUID().uuidString
             let payload = "hello"
-            func getWork() -> GetWorkResult {
+            func getInvocation() -> GetInvocationResult {
                 .success((self.requestId, self.payload))
             }
 
@@ -47,7 +47,7 @@ class LambdaRunnerTest: XCTestCase {
         struct Behavior: LambdaServerBehavior {
             static let error = "boom"
             let requestId = UUID().uuidString
-            func getWork() -> GetWorkResult {
+            func getInvocation() -> GetInvocationResult {
                 .success((requestId: self.requestId, payload: "hello"))
             }
 

--- a/Tests/AWSLambdaRuntimeTests/LambdaRuntimeClientTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRuntimeClientTest.swift
@@ -36,9 +36,9 @@ class LambdaRuntimeClientTest: XCTestCase {
         XCTAssertEqual(behavior.state, 1)
     }
 
-    func testGetWorkServerInternalError() {
+    func testGetInvocationServerInternalError() {
         struct Behavior: LambdaServerBehavior {
-            func getWork() -> GetWorkResult {
+            func getInvocation() -> GetInvocationResult {
                 .failure(.internalServerError)
             }
 
@@ -62,9 +62,9 @@ class LambdaRuntimeClientTest: XCTestCase {
         }
     }
 
-    func testGetWorkServerNoBodyError() {
+    func testGetInvocationServerNoBodyError() {
         struct Behavior: LambdaServerBehavior {
-            func getWork() -> GetWorkResult {
+            func getInvocation() -> GetInvocationResult {
                 .success(("1", ""))
             }
 
@@ -88,9 +88,9 @@ class LambdaRuntimeClientTest: XCTestCase {
         }
     }
 
-    func testGetWorkServerMissingHeaderRequestIDError() {
+    func testGetInvocationServerMissingHeaderRequestIDError() {
         struct Behavior: LambdaServerBehavior {
-            func getWork() -> GetWorkResult {
+            func getInvocation() -> GetInvocationResult {
                 // no request id -> no context
                 .success(("", "hello"))
             }
@@ -117,7 +117,7 @@ class LambdaRuntimeClientTest: XCTestCase {
 
     func testProcessResponseInternalServerError() {
         struct Behavior: LambdaServerBehavior {
-            func getWork() -> GetWorkResult {
+            func getInvocation() -> GetInvocationResult {
                 .success((requestId: "1", payload: "payload"))
             }
 
@@ -142,7 +142,7 @@ class LambdaRuntimeClientTest: XCTestCase {
 
     func testProcessErrorInternalServerError() {
         struct Behavior: LambdaServerBehavior {
-            func getWork() -> GetWorkResult {
+            func getInvocation() -> GetInvocationResult {
                 .success((requestId: "1", payload: "payload"))
             }
 
@@ -167,8 +167,8 @@ class LambdaRuntimeClientTest: XCTestCase {
 
     func testProcessInitErrorOnBootstrapFailure() {
         struct Behavior: LambdaServerBehavior {
-            func getWork() -> GetWorkResult {
-                XCTFail("should not get work")
+            func getInvocation() -> GetInvocationResult {
+                XCTFail("should not get invocation")
                 return .failure(.internalServerError)
             }
 
@@ -217,7 +217,7 @@ class LambdaRuntimeClientTest: XCTestCase {
             return .success(())
         }
 
-        func getWork() -> GetWorkResult {
+        func getInvocation() -> GetInvocationResult {
             self.state += 2
             return .success(("1", "hello"))
         }

--- a/Tests/AWSLambdaRuntimeTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaTest.swift
@@ -100,8 +100,8 @@ class LambdaTest: XCTestCase {
 
     func testBootstrapFailureAndReportErrorFailure() {
         struct Behavior: LambdaServerBehavior {
-            func getWork() -> GetWorkResult {
-                XCTFail("should not get work")
+            func getInvocation() -> GetInvocationResult {
+                XCTFail("should not get invocation")
                 return .failure(.internalServerError)
             }
 
@@ -212,7 +212,7 @@ class LambdaTest: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         struct Behavior: LambdaServerBehavior {
-            func getWork() -> GetWorkResult {
+            func getInvocation() -> GetInvocationResult {
                 .failure(.internalServerError)
             }
 
@@ -299,7 +299,7 @@ private struct Behavior: LambdaServerBehavior {
         self.result = result
     }
 
-    func getWork() -> GetWorkResult {
+    func getInvocation() -> GetInvocationResult {
         .success((requestId: self.requestId, payload: self.payload))
     }
 
@@ -334,8 +334,8 @@ private struct Behavior: LambdaServerBehavior {
 }
 
 struct FailedBootstrapBehavior: LambdaServerBehavior {
-    func getWork() -> GetWorkResult {
-        XCTFail("should not get work")
+    func getInvocation() -> GetInvocationResult {
+        XCTFail("should not get invocation")
         return .failure(.internalServerError)
     }
 

--- a/Tests/AWSLambdaRuntimeTests/MockLambdaServer.swift
+++ b/Tests/AWSLambdaRuntimeTests/MockLambdaServer.swift
@@ -130,8 +130,8 @@ internal final class HTTPHandler: ChannelInboundHandler {
             case .failure(let error):
                 responseStatus = .init(statusCode: error.rawValue)
             }
-        } else if request.head.uri.hasSuffix(Consts.requestWorkURLSuffix) {
-            switch self.behavior.getWork() {
+        } else if request.head.uri.hasSuffix(Consts.getNextInvocationURLSuffix) {
+            switch self.behavior.getInvocation() {
             case .success(let (requestId, result)):
                 if requestId == "timeout" {
                     usleep((UInt32(result) ?? 0) * 1000)
@@ -213,13 +213,13 @@ internal final class HTTPHandler: ChannelInboundHandler {
 }
 
 internal protocol LambdaServerBehavior {
-    func getWork() -> GetWorkResult
+    func getInvocation() -> GetInvocationResult
     func processResponse(requestId: String, response: String?) -> Result<Void, ProcessResponseError>
     func processError(requestId: String, error: ErrorResponse) -> Result<Void, ProcessErrorError>
     func processInitError(error: ErrorResponse) -> Result<Void, ProcessErrorError>
 }
 
-internal typealias GetWorkResult = Result<(String, String), GetWorkError>
+internal typealias GetInvocationResult = Result<(String, String), GetWorkError>
 
 internal enum GetWorkError: Int, Error {
     case badRequest = 400


### PR DESCRIPTION
### Motivation

Make the naming more consistent with AWS' API naming.

### Changes

`requestWork` has been renamed to `getNextInvocation`