### PR TITLE
fix context members to follow swift APi guidelines

### DIFF
--- a/Examples/LambdaFunctions/Sources/ErrorHandling/main.swift
+++ b/Examples/LambdaFunctions/Sources/ErrorHandling/main.swift
@@ -21,10 +21,10 @@ Lambda.run { (context: Lambda.Context, request: Request, callback: (Result<Respo
     switch request.error {
     // no error here!
     case .none:
-        callback(.success(Response(awsRequestId: context.requestId, requestId: request.requestId, status: .ok)))
+        callback(.success(Response(awsRequestID: context.requestID, requestID: request.requestID, status: .ok)))
     // trigger a "managed" error - domain specific business logic failure
     case .managed:
-        callback(.success(Response(awsRequestId: context.requestId, requestId: request.requestId, status: .error)))
+        callback(.success(Response(awsRequestID: context.requestID, requestID: request.requestID, status: .error)))
     // trigger an "unmanaged" error - an unexpected Swift Error triggered while processing the request
     case .unmanaged(let error):
         callback(.failure(UnmanagedError(description: error)))
@@ -37,11 +37,11 @@ Lambda.run { (context: Lambda.Context, request: Request, callback: (Result<Respo
 // MARK: - Request and Response
 
 struct Request: Codable {
-    let requestId: String
+    let requestID: String
     let error: Error
 
-    public init(requestId: String, error: Error? = nil) {
-        self.requestId = requestId
+    public init(requestID: String, error: Error? = nil) {
+        self.requestID = requestID
         self.error = error ?? .none
     }
 
@@ -80,13 +80,13 @@ struct Request: Codable {
 }
 
 struct Response: Codable {
-    let awsRequestId: String
-    let requestId: String
+    let awsRequestID: String
+    let requestID: String
     let status: Status
 
-    public init(awsRequestId: String, requestId: String, status: Status) {
-        self.awsRequestId = awsRequestId
-        self.requestId = requestId
+    public init(awsRequestID: String, requestID: String, status: Status) {
+        self.awsRequestID = awsRequestID
+        self.requestID = requestID
         self.status = status
     }
 

--- a/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaContext.swift
@@ -21,13 +21,13 @@ extension Lambda {
     /// The Lambda runtime generates and passes the `Context` to the Lambda handler as an argument.
     public final class Context: CustomDebugStringConvertible {
         /// The request ID, which identifies the request that triggered the function invocation.
-        public let requestId: String
+        public let requestID: String
 
         /// The AWS X-Ray tracing header.
-        public let traceId: String
+        public let traceID: String
 
         /// The ARN of the Lambda function, version, or alias that's specified in the invocation.
-        public let invokedFunctionArn: String
+        public let invokedFunctionARN: String
 
         /// The timestamp that the function times out
         public let deadline: DispatchWallTime
@@ -54,17 +54,17 @@ extension Lambda {
         /// This is useful when implementing `EventLoopLambdaHandler`
         public let allocator: ByteBufferAllocator
 
-        internal init(requestId: String,
-                      traceId: String,
-                      invokedFunctionArn: String,
+        internal init(requestID: String,
+                      traceID: String,
+                      invokedFunctionARN: String,
                       deadline: DispatchWallTime,
                       cognitoIdentity: String? = nil,
                       clientContext: String? = nil,
                       logger: Logger,
                       eventLoop: EventLoop) {
-            self.requestId = requestId
-            self.traceId = traceId
-            self.invokedFunctionArn = invokedFunctionArn
+            self.requestID = requestID
+            self.traceID = traceID
+            self.invokedFunctionARN = invokedFunctionARN
             self.cognitoIdentity = cognitoIdentity
             self.clientContext = clientContext
             self.deadline = deadline
@@ -73,8 +73,8 @@ extension Lambda {
             self.allocator = ByteBufferAllocator()
             // mutate logger with context
             var logger = logger
-            logger[metadataKey: "awsRequestId"] = .string(requestId)
-            logger[metadataKey: "awsTraceId"] = .string(traceId)
+            logger[metadataKey: "awsRequestID"] = .string(requestID)
+            logger[metadataKey: "awsTraceID"] = .string(traceID)
             self.logger = logger
         }
 
@@ -87,7 +87,7 @@ extension Lambda {
         }
 
         public var debugDescription: String {
-            "\(Self.self)(requestId: \(self.requestId), traceId: \(self.traceId), invokedFunctionArn: \(self.invokedFunctionArn), cognitoIdentity: \(self.cognitoIdentity ?? "nil"), clientContext: \(self.clientContext ?? "nil"), deadline: \(self.deadline))"
+            "\(Self.self)(requestID: \(self.requestID), traceID: \(self.traceID), invokedFunctionARN: \(self.invokedFunctionARN), cognitoIdentity: \(self.cognitoIdentity ?? "nil"), clientContext: \(self.clientContext ?? "nil"), deadline: \(self.deadline))"
         }
     }
 }

--- a/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRunner.swift
@@ -83,9 +83,9 @@ extension Lambda {
 
 private extension Lambda.Context {
     convenience init(logger: Logger, eventLoop: EventLoop, invocation: Lambda.Invocation) {
-        self.init(requestId: invocation.requestId,
-                  traceId: invocation.traceId,
-                  invokedFunctionArn: invocation.invokedFunctionArn,
+        self.init(requestID: invocation.requestID,
+                  traceID: invocation.traceID,
+                  invokedFunctionARN: invocation.invokedFunctionARN,
                   deadline: DispatchWallTime(millisSinceEpoch: invocation.deadlineInMillisSinceEpoch),
                   cognitoIdentity: invocation.cognitoIdentity,
                   clientContext: invocation.clientContext,

--- a/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntimeCore/LambdaRuntimeClient.swift
@@ -59,7 +59,7 @@ extension Lambda {
 
         /// Reports a result to the Runtime Engine.
         func reportResults(logger: Logger, invocation: Invocation, result: Result<ByteBuffer?, Error>) -> EventLoopFuture<Void> {
-            var url = Consts.invocationURLPrefix + "/" + invocation.requestId
+            var url = Consts.invocationURLPrefix + "/" + invocation.requestID
             var body: ByteBuffer?
             switch result {
             case .success(let buffer):
@@ -152,15 +152,15 @@ internal extension ErrorResponse {
 
 extension Lambda {
     internal struct Invocation {
-        let requestId: String
+        let requestID: String
         let deadlineInMillisSinceEpoch: Int64
-        let invokedFunctionArn: String
-        let traceId: String
+        let invokedFunctionARN: String
+        let traceID: String
         let clientContext: String?
         let cognitoIdentity: String?
 
         init(headers: HTTPHeaders) throws {
-            guard let requestId = headers.first(name: AmazonHeaders.requestID), !requestId.isEmpty else {
+            guard let requestID = headers.first(name: AmazonHeaders.requestID), !requestID.isEmpty else {
                 throw RuntimeError.invocationMissingHeader(AmazonHeaders.requestID)
             }
 
@@ -169,18 +169,18 @@ extension Lambda {
                 throw RuntimeError.invocationMissingHeader(AmazonHeaders.deadline)
             }
 
-            guard let invokedFunctionArn = headers.first(name: AmazonHeaders.invokedFunctionARN) else {
+            guard let invokedFunctionARN = headers.first(name: AmazonHeaders.invokedFunctionARN) else {
                 throw RuntimeError.invocationMissingHeader(AmazonHeaders.invokedFunctionARN)
             }
 
-            guard let traceId = headers.first(name: AmazonHeaders.traceID) else {
+            guard let traceID = headers.first(name: AmazonHeaders.traceID) else {
                 throw RuntimeError.invocationMissingHeader(AmazonHeaders.traceID)
             }
 
-            self.requestId = requestId
+            self.requestID = requestID
             self.deadlineInMillisSinceEpoch = unixTimeInMilliseconds
-            self.invokedFunctionArn = invokedFunctionArn
-            self.traceId = traceId
+            self.invokedFunctionARN = invokedFunctionARN
+            self.traceID = traceID
             self.clientContext = headers["Lambda-Runtime-Client-Context"].first
             self.cognitoIdentity = headers["Lambda-Runtime-Cognito-Identity"].first
         }

--- a/Sources/AWSLambdaTesting/Lambda+Testing.swift
+++ b/Sources/AWSLambdaTesting/Lambda+Testing.swift
@@ -42,18 +42,18 @@ import NIO
 
 extension Lambda {
     public struct TestConfig {
-        public var requestId: String
-        public var traceId: String
-        public var invokedFunctionArn: String
+        public var requestID: String
+        public var traceID: String
+        public var invokedFunctionARN: String
         public var timeout: DispatchTimeInterval
 
-        public init(requestId: String = "\(DispatchTime.now().uptimeNanoseconds)",
-                    traceId: String = "Root=\(DispatchTime.now().uptimeNanoseconds);Parent=\(DispatchTime.now().uptimeNanoseconds);Sampled=1",
-                    invokedFunctionArn: String = "arn:aws:lambda:us-west-1:\(DispatchTime.now().uptimeNanoseconds):function:custom-runtime",
+        public init(requestID: String = "\(DispatchTime.now().uptimeNanoseconds)",
+                    traceID: String = "Root=\(DispatchTime.now().uptimeNanoseconds);Parent=\(DispatchTime.now().uptimeNanoseconds);Sampled=1",
+                    invokedFunctionARN: String = "arn:aws:lambda:us-west-1:\(DispatchTime.now().uptimeNanoseconds):function:custom-runtime",
                     timeout: DispatchTimeInterval = .seconds(5)) {
-            self.requestId = requestId
-            self.traceId = traceId
-            self.invokedFunctionArn = invokedFunctionArn
+            self.requestID = requestID
+            self.traceID = traceID
+            self.invokedFunctionARN = invokedFunctionARN
             self.timeout = timeout
         }
     }
@@ -97,9 +97,9 @@ extension Lambda {
             try! eventLoopGroup.syncShutdownGracefully()
         }
         let eventLoop = eventLoopGroup.next()
-        let context = Context(requestId: config.requestId,
-                              traceId: config.traceId,
-                              invokedFunctionArn: config.invokedFunctionArn,
+        let context = Context(requestID: config.requestID,
+                              traceID: config.traceID,
+                              invokedFunctionARN: config.invokedFunctionARN,
                               deadline: .now() + config.timeout,
                               logger: logger,
                               eventLoop: eventLoop)

--- a/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
+++ b/Tests/AWSLambdaRuntimeCoreTests/LambdaTest.swift
@@ -256,9 +256,9 @@ class LambdaTest: XCTestCase {
         let past2 = DispatchWallTime(millisSinceEpoch: Date(timeIntervalSinceNow: Double(-delta)).millisSinceEpoch)
         XCTAssertEqual(Double(past1.rawValue), Double(past2.rawValue), accuracy: 2_000_000.0)
 
-        let context = Lambda.Context(requestId: UUID().uuidString,
-                                     traceId: UUID().uuidString,
-                                     invokedFunctionArn: UUID().uuidString,
+        let context = Lambda.Context(requestID: UUID().uuidString,
+                                     traceID: UUID().uuidString,
+                                     invokedFunctionARN: UUID().uuidString,
                                      deadline: .now() + .seconds(1),
                                      cognitoIdentity: nil,
                                      clientContext: nil,
@@ -266,9 +266,9 @@ class LambdaTest: XCTestCase {
                                      eventLoop: MultiThreadedEventLoopGroup(numberOfThreads: 1).next())
         XCTAssertGreaterThan(context.deadline, .now())
 
-        let expiredContext = Lambda.Context(requestId: context.requestId,
-                                            traceId: context.traceId,
-                                            invokedFunctionArn: context.invokedFunctionArn,
+        let expiredContext = Lambda.Context(requestID: context.requestID,
+                                            traceID: context.traceID,
+                                            invokedFunctionARN: context.invokedFunctionARN,
                                             deadline: .now() - .seconds(1),
                                             cognitoIdentity: context.cognitoIdentity,
                                             clientContext: context.clientContext,
@@ -278,9 +278,9 @@ class LambdaTest: XCTestCase {
     }
 
     func testGetRemainingTime() {
-        let context = Lambda.Context(requestId: UUID().uuidString,
-                                     traceId: UUID().uuidString,
-                                     invokedFunctionArn: UUID().uuidString,
+        let context = Lambda.Context(requestID: UUID().uuidString,
+                                     traceID: UUID().uuidString,
+                                     invokedFunctionARN: UUID().uuidString,
                                      deadline: .now() + .seconds(1),
                                      cognitoIdentity: nil,
                                      clientContext: nil,

--- a/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
+++ b/Tests/AWSLambdaRuntimeTests/Lambda+CodeableTest.swift
@@ -65,9 +65,9 @@ class CodableLambdaTest: XCTestCase {
 
     // convencience method
     func newContext() -> Lambda.Context {
-        Lambda.Context(requestId: UUID().uuidString,
-                       traceId: "abc123",
-                       invokedFunctionArn: "aws:arn:",
+        Lambda.Context(requestID: UUID().uuidString,
+                       traceID: "abc123",
+                       invokedFunctionARN: "aws:arn:",
                        deadline: .now() + .seconds(3),
                        cognitoIdentity: nil,
                        clientContext: nil,

--- a/Tests/AWSLambdaTestingTests/Tests.swift
+++ b/Tests/AWSLambdaTestingTests/Tests.swift
@@ -125,16 +125,16 @@ class LambdaTestingTests: XCTestCase {
     func testConfigValues() {
         let timeout: TimeInterval = 4
         let config = Lambda.TestConfig(
-            requestId: UUID().uuidString,
-            traceId: UUID().uuidString,
-            invokedFunctionArn: "arn:\(UUID().uuidString)",
+            requestID: UUID().uuidString,
+            traceID: UUID().uuidString,
+            invokedFunctionARN: "arn:\(UUID().uuidString)",
             timeout: .seconds(4)
         )
 
         let myLambda = { (ctx: Lambda.Context, _: String, callback: @escaping (Result<Void, Error>) -> Void) in
-            XCTAssertEqual(ctx.requestId, config.requestId)
-            XCTAssertEqual(ctx.traceId, config.traceId)
-            XCTAssertEqual(ctx.invokedFunctionArn, config.invokedFunctionArn)
+            XCTAssertEqual(ctx.requestID, config.requestID)
+            XCTAssertEqual(ctx.traceID, config.traceID)
+            XCTAssertEqual(ctx.invokedFunctionARN, config.invokedFunctionARN)
 
             let secondsSinceEpoch = Double(Int64(bitPattern: ctx.deadline.rawValue)) / -1_000_000_000
             XCTAssertEqual(Date(timeIntervalSince1970: secondsSinceEpoch).timeIntervalSinceNow, timeout, accuracy: 0.1)

--- a/readme.md
+++ b/readme.md
@@ -235,13 +235,13 @@ When calling the user provided Lambda function, the library provides a `Context`
 ```swift
 public final class Context {
     /// The request ID, which identifies the request that triggered the function invocation.
-    public let requestId: String
+    public let requestID: String
 
     /// The AWS X-Ray tracing header.
-    public let traceId: String
+    public let traceID: String
 
     /// The ARN of the Lambda function, version, or alias that's specified in the invocation.
-    public let invokedFunctionArn: String
+    public let invokedFunctionARN: String
 
     /// The timestamp that the function times out
     public let deadline: DispatchWallTime


### PR DESCRIPTION
motivation: nicer API

changes:
* requestID -> requestID
* traceId -> traceID
* invokedFunctionArn -> invokedFunctionARN