### PR TITLE
Instructions for customizing the output path are incorrect

### DIFF
--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -307,7 +307,7 @@ struct AWSLambdaPackager: CommandPlugin {
 
             USAGE: swift package --allow-network-connections docker archive
                                                        [--help] [--verbose]
-                                                       [--output-directory <path>]
+                                                       [--output-path <path>]
                                                        [--products <list of products>]
                                                        [--configuration debug | release]
                                                        [--swift-version <version>]
@@ -317,7 +317,7 @@ struct AWSLambdaPackager: CommandPlugin {
 
             OPTIONS:
             --verbose                     Produce verbose output for debugging.
-            --output-directory <path>     The path of the binary package.
+            --output-path <path>          The path of the binary package.
                                           (default is `.build/plugins/AWSLambdaPackager/outputs/...`)
             --products <list>             The list of executable targets to build.
                                           (default is taken from Package.swift)


### PR DESCRIPTION
Instructions for customizing the output path are incorrect

### Motivation:

`displayHelpMessage` was incorrect - it claimed that the output path was customizable via a `--output-directory` flag, but the code actually looks for `--output-path`

### Modifications:

Changing the help message here, instead of the code, in case existing projects already depend on `--output-path`

### Result:

`displayHelpMessage` will show the correct instructions