### PR TITLE
fix ci : check libFoundation on HelloWorld example

### DIFF
--- a/.github/workflows/scripts/check-link-foundation.sh
+++ b/.github/workflows/scripts/check-link-foundation.sh
@@ -17,23 +17,23 @@ log() { printf -- "** %s\n" "$*" >&2; }
 error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
-EXAMPLE=APIGatewayV2
+EXAMPLE=HelloWorld
 OUTPUT_DIR=.build/release
-OUTPUT_FILE=${OUTPUT_DIR}/APIGatewayLambda
+OUTPUT_FILE=${OUTPUT_DIR}/MyLambda
 LIBS_TO_CHECK="libFoundation.so libFoundationInternationalization.so lib_FoundationICU.so"
 
 pushd Examples/${EXAMPLE} || fatal "Failed to change directory to Examples/${EXAMPLE}."
 
 # recompile the example without the --static-swift-stdlib flag
-LAMBDA_USE_LOCAL_DEPS=../.. swift build -c release -Xlinker -s || fatal "Failed to build the example."
+LAMBDA_USE_LOCAL_DEPS=../.. swift build -c release || fatal "Failed to build the example."
 
 # check if the binary exists
 if [ ! -f "${OUTPUT_FILE}" ]; then
-  error "❌ ${OUTPUT_FILE} does not exist."
+  fatal "❌ ${OUTPUT_FILE} does not exist."
 fi
 
 # Checking for Foundation or ICU dependencies
-echo "Checking for Foundation or ICU dependencies in ${OUTPUT_DIR}/${OUTPUT_FILE}."
+echo "Checking for Foundation or ICU dependencies in ${OUTPUT_FILE}."
 LIBRARIES=$(ldd ${OUTPUT_FILE} | awk '{print $1}')
 for LIB in ${LIBS_TO_CHECK}; do
   echo -n "Checking for ${LIB}... "

--- a/Sources/AWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime.swift
@@ -16,12 +16,6 @@ import Logging
 import NIOCore
 import Synchronization
 
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-
 // This is our guardian to ensure only one LambdaRuntime is running at the time
 // We use an Atomic here to ensure thread safety
 @available(LambdaSwift 2.0, *)


### PR DESCRIPTION
Fix errors in the CI
The script that checks the presence of `libFoundation` in the binary started to fail. 
I can't think about a recent change that would cause this.

This PR change the test script to use the `HelloWorld` example instead of `APIGAtewayV2` 