### PR TITLE
[ci] Use APIGatewayV2 for link foundation check

### DIFF
--- a/.github/workflows/scripts/check-link-foundation.sh
+++ b/.github/workflows/scripts/check-link-foundation.sh
@@ -17,9 +17,9 @@ log() { printf -- "** %s\n" "$*" >&2; }
 error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
-EXAMPLE=HelloWorld
+EXAMPLE=APIGatewayV2
 OUTPUT_DIR=.build/release
-OUTPUT_FILE=${OUTPUT_DIR}/MyLambda
+OUTPUT_FILE=${OUTPUT_DIR}/APIGatewayLambda
 LIBS_TO_CHECK="libFoundation.so libFoundationInternationalization.so lib_FoundationICU.so"
 
 pushd Examples/${EXAMPLE} || fatal "Failed to change directory to Examples/${EXAMPLE}."


### PR DESCRIPTION
Revert change on https://github.com/awslabs/swift-aws-lambda-runtime/pull/593

The root cause has been addressed in the Swift AWS Lambda Event library 
https://github.com/awslabs/swift-aws-lambda-events/pull/99