### PR TITLE
Makes performance script run on macOS

### DIFF
--- a/Sources/AWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime.swift
@@ -104,13 +104,15 @@ public final class LambdaRuntime<Handler>: Sendable where Handler: StreamingLamb
             } catch {
                 // catch top level errors that have not been handled until now
                 // this avoids the runtime to crash and generate a backtrace
-                self.logger.error("LambdaRuntime.run() failed with error", metadata: ["error": "\(error)"])
                 if let error = error as? LambdaRuntimeError,
                     error.code != .connectionToControlPlaneLost
                 {
                     // if the error is a LambdaRuntimeError but not a connection error,
                     // we rethrow it to preserve existing behaviour
+                    self.logger.error("LambdaRuntime.run() failed with error", metadata: ["error": "\(error)"])
                     throw error
+                } else {
+                    self.logger.trace("LambdaRuntime.run() connection lost")
                 }
             }
 

--- a/scripts/performance_test.sh
+++ b/scripts/performance_test.sh
@@ -19,7 +19,7 @@ error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
 export HOST=127.0.0.1
-export PORT=7000
+export PORT=7777
 export AWS_LAMBDA_RUNTIME_API="$HOST:$PORT"
 export LOG_LEVEL=error # important, otherwise log becomes a bottleneck
 


### PR DESCRIPTION
By default, the script started the MockServer on port 7000, which is used by AirPlay on macOS.
This caused conflicts.

I also made a minor change on the logging to avoir reporting an error when the server closes the connection.
