### PR TITLE
fix #609 : [plugin] Update the README and the doc to mention potential credentials error when using the plugin.

### DIFF
--- a/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
@@ -73,6 +73,11 @@ Here is the content of this guide:
    >[!NOTE]
    > When building on Linux, your current user must have permission to use docker. On most Linux distributions, you can do so by adding your user to the `docker` group with the following command: `sudo usermod -aG docker $USER`. You must log out and log back in for the changes to take effect.
 
+   >[!NOTE]
+   > If you encounter Docker credential store errors during the build, remove the `credsStore` entry from your `~/.docker/config.json` file or disable the plugin sandbox with `--disable-sandbox`. See [issue #609](https://github.com/awslabs/swift-aws-lambda-runtime/issues/609) for details.
+
+   
+
 ### Choosing the AWS Region where to deploy
 
 [AWS Global infrastructure](https://aws.amazon.com/about-aws/global-infrastructure/) spans over 34 geographic Regions (and continuously expanding). When you create a resource on AWS, such as a Lambda function, you have to select a geographic region where the resource will be created. The two main factors to consider to select a Region are the physical proximity with your users and geographical compliance. 

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,9 @@ swift package archive --allow-network-connections docker
 If there is no error, the ZIP archive is ready to deploy.
 The ZIP file is located at `.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip`
 
+ >[!NOTE]
+   > If you encounter Docker credential store errors during the build, remove the `credsStore` entry from your `~/.docker/config.json` file or disable the plugin sandbox with `--disable-sandbox`. See [issue #609](https://github.com/awslabs/swift-aws-lambda-runtime/issues/609) for details.
+
 5. Deploy to AWS
 
 There are multiple ways to deploy to AWS ([SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html), [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started), [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html), [AWS Console](https://docs.aws.amazon.com/lambda/latest/dg/getting-started.html)) that are covered later in this doc.


### PR DESCRIPTION
## Description

Adds documentation for Docker credential store errors that users may encounter when running `swift package archive --allow-network-connections docker`.

## Changes

- Added a note in `readme.md` explaining how to resolve Docker credential store errors
- Added a note in `Sources/AWSLambdaRuntime/Docs.docc/Deployment.md` with the same guidance

## Problem

Users may encounter authentication errors when the Swift package plugin attempts to pull Docker images, particularly when Docker is configured with a credential store (e.g., `docker-credential-desktop`). This issue is documented in #609.

## Solution

The documentation now provides two workarounds:
1. Remove the `credsStore` entry from `~/.docker/config.json`
2. Use the `--disable-sandbox` flag with the archive command

Both notes link to issue #609 for additional context and discussion.

## Related Issue

Fixes #609
