### PR TITLE
fix(runtime): fix ambiguous use of init log error

### DIFF
--- a/Sources/AWSLambdaRuntime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/LambdaRuntime.swift
@@ -47,7 +47,7 @@ public final class LambdaRuntime<Handler>: Sendable where Handler: StreamingLamb
 
         // use the LOG_LEVEL environment variable to set the log level.
         // if the environment variable is not set, use the default log level from the logger provided
-        log.logLevel = Lambda.env("LOG_LEVEL").flatMap(Logger.Level.init) ?? logger.logLevel
+        log.logLevel = Lambda.env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? logger.logLevel
 
         self.logger = log
         self.logger.debug("LambdaRuntime initialized")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When compiling with Swift 6.0+, the build fails with an "ambiguous use of 'init'" error in `LambdaRuntime.swift`. I have created a minimal reproduction repo that is available here: https://github.com/luke-h1/lambda-logger-reproduction


I've seen this occur in the following evenironments
- **Swift version:** 6.0 / 6.2
- **swift-aws-lambda-runtime version:** 2.4.0
- **swift-log version:** 1.6.0+
- **Platform:** macOS 15 / Amazon Linux 2


## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
N/A - This is a new issue I came across when trying to convert my lambda function to Swift 

## Description of changes
`Logger.Level` has two failable initializers that both accept a `String`:
- `init?(rawValue: String)` 
- `init?(_ description: String)`

When using `flatMap(Logger.Level.init)`, Swift 6's stricter type inference cannot disambiguate which initializer to use, resulting in this error: 

```
.build/checkouts/swift-aws-lambda-runtime/Sources/AWSLambdaRuntime/LambdaRuntime.swift:50:69: error: ambiguous use of 'init'
 48 |         // use the LOG_LEVEL environment variable to set the log level.
 49 |         // if the environment variable is not set, use the default log level from the logger provided
 50 |         log.logLevel = Lambda.env("LOG_LEVEL").flatMap(Logger.Level.init) ?? logger.logLevel
    |                                                                     `- error: ambiguous use of 'init'
 51 | 
 52 |         self.logger = log
```

I'm a little new to Swift so if there's anything I need to do around accounting for previous versions of swift please let me know and I will add to this PR 👍 

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.