### PR TITLE
Lift up the trace limit on payload to make it actually useful when debugging

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -48,9 +48,9 @@ public enum Lambda {
                 let (invocation, writer) = try await runtimeClient.nextInvocation()
                 logger[metadataKey: "aws-request-id"] = "\(invocation.metadata.requestID)"
 
-                // when log level is trace or lower, print the first Kb of the payload
+                // when log level is trace or lower, print the first 6 Mb of the payload
                 let bytes = invocation.event
-                let maxPayloadPreviewSize = 1024
+                let maxPayloadPreviewSize = 6 * 1024 * 1024
                 var metadata: Logger.Metadata? = nil
                 if logger.logLevel <= .trace,
                     let buffer = bytes.getSlice(at: 0, length: min(bytes.readableBytes, maxPayloadPreviewSize))


### PR DESCRIPTION
When using `trace` log level the runtime diplays 1Kb of the input payload to help debugging cases where the JSON decoding fails. Most of the type, this 1 Kb trace is not enough to understand what part of the incoming JSON fails to decode.

This PR raises the limit to 6Mb to be actually useful. 