### PR TITLE
Fix for swift test : _Concurrency/Executor.swift:357: Fatal error

### DIFF
--- a/Sources/AWSLambdaRuntime/HTTPClient/LambdaRuntimeClient.swift
+++ b/Sources/AWSLambdaRuntime/HTTPClient/LambdaRuntimeClient.swift
@@ -145,7 +145,7 @@ final actor LambdaRuntimeClient: LambdaRuntimeClientProtocol {
     /// the same unsafe cast that `assumeIsolated` does internally after its check passes.
     /// See: https://github.com/swiftlang/swift/blob/main/stdlib/public/Concurrency/ExecutorAssertions.swift#L348
     /// See: https://forums.swift.org/t/actor-assumeisolated-erroneously-crashes-when-using-a-dispatch-queue-as-the-underlying-executor/72434/3
-    nonisolated func assumeIsolatedOnEventLoop(
+    private nonisolated func assumeIsolatedOnEventLoop(
         _ operation: (isolated LambdaRuntimeClient) -> Void
     ) {
         self.eventLoop.preconditionInEventLoop()
@@ -461,7 +461,7 @@ final actor LambdaRuntimeClient: LambdaRuntimeClientProtocol {
                     "lambda_ip": "\(self.configuration.ip)",
                 ]
             )
-            channel.closeFuture.whenComplete { result in
+            channel.closeFuture.whenComplete { _ in
                 self.assumeIsolatedOnEventLoop { runtimeClient in
                     // close the channel
                     runtimeClient.channelClosed(channel)


### PR DESCRIPTION
Fix the issue described at https://github.com/awslabs/swift-aws-lambda-runtime/issues/640

Here is the proposed fix:

I added a new function `assumeIsolatedOnEventLoop` — a nonisolated method that:
1. Calls `self.eventLoop.preconditionInEventLoop()` to verify we're on the correct event loop (NIO's own thread-identity check, which always works)
2. Uses `unsafeBitCast` to strip the isolated annotation, the same pattern NIO uses internally and that I found on the Swift Forums.

See: https://github.com/swiftlang/swift/blob/main/stdlib/public/Concurrency/ExecutorAssertions.swift#L348

See: https://forums.swift.org/t/actor-assumeisolated-erroneously-crashes-when-using-a-dispatch-queue-as-the-underlying-executor/72434/3
