### PR TITLE
Fix more crashes in archive

### DIFF
--- a/Plugins/AWSLambdaPackager/PluginUtils.swift
+++ b/Plugins/AWSLambdaPackager/PluginUtils.swift
@@ -95,7 +95,9 @@ struct Utils {
         // triggers _bridgeAnythingToObjectiveC / swift_dynamicCast which can
         // crash with a SIGSEGV during concurrent Swift runtime metadata resolution.
         let readFileHandle = pipe.fileHandleForReading
+        outputSync.enter()
         outputQueue.async {
+            defer { outputSync.leave() }
             // Read in a loop until EOF
             while true {
                 let data = readFileHandle.availableData


### PR DESCRIPTION
## Issue #
Related to intermittent CI crashes with Signal 11 (SIGSEGV) during `swift package archive` on Linux x86_64 (Ubuntu 24.04) 

## Description of the changes
Replaces `FileHandle.readabilityHandler` with a manual blocking read loop using `availableData` on a serial `DispatchQueue` in the `Utils.execute` method of the AWSLambdaPackager plugin.

On Linux, `FileHandle.readabilityHandler`'s setter internally calls `_bridgeAnythingToObjectiveC`, which triggers `swift_dynamicCast` / `swift_conformsToProtocol`. When the Swift runtime is concurrently resolving type metadata on other threads, this causes a bad pointer dereference crash in `_dispatch_event_loop_drain`. The new approach uses a `while` loop calling `availableData` (blocks until data arrives, returns empty `Data` at EOF), completely avoiding the problematic Foundation/ObjC bridging code paths.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

## Conventional Commits
`fix: replace FileHandle.readabilityHandler with manual read loop in AWSLambdaPackager plugin`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
