### PR TITLE
Correctly propagate the trace ID

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.3.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.10.1"),
+        .package(url: "https://github.com/apple/swift-service-context.git", from: "1.3.0"),
     ],
     targets: [
         .target(
@@ -44,6 +45,7 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "ServiceContextModule", package: "swift-service-context"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(
@@ -74,6 +76,7 @@ let package = Package(
             name: "AWSLambdaRuntimeTests",
             dependencies: [
                 .byName(name: "AWSLambdaRuntime"),
+                .product(name: "ServiceContextModule", package: "swift-service-context"),
                 .product(name: "NIOTestUtils", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ],

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -25,6 +25,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.8.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.3.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.9.0"),
+        .package(url: "https://github.com/apple/swift-service-context.git", from: "1.3.0"),
     ],
     targets: [
         .target(
@@ -35,6 +36,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "ServiceContextModule", package: "swift-service-context"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
             ],
             swiftSettings: defaultSwiftSettings
@@ -61,6 +63,7 @@ let package = Package(
                 .byName(name: "AWSLambdaRuntime"),
                 .product(name: "NIOTestUtils", package: "swift-nio"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "ServiceContextModule", package: "swift-service-context"),
             ],
             swiftSettings: defaultSwiftSettings
         ),

--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -53,6 +53,28 @@ public enum Lambda {
         )
     }
 
+    @available(
+        *,
+        deprecated,
+        message:
+            "This method will be removed in a future major version update. Use runLoop(runtimeClient:handler:loggingConfiguration:logger:isSingleConcurrencyMode:) instead."
+    )
+    @inlinable
+    package static func runLoop<RuntimeClient: LambdaRuntimeClientProtocol, Handler>(
+        runtimeClient: RuntimeClient,
+        handler: Handler,
+        loggingConfiguration: LoggingConfiguration,
+        logger: Logger
+    ) async throws where Handler: StreamingLambdaHandler {
+        try await self.runLoop(
+            runtimeClient: runtimeClient,
+            handler: handler,
+            loggingConfiguration: LoggingConfiguration(logger: logger),
+            logger: logger,
+            isSingleConcurrencyMode: true
+        )
+    }
+
     @inlinable
     package static func runLoop<RuntimeClient: LambdaRuntimeClientProtocol, Handler>(
         runtimeClient: RuntimeClient,

--- a/Sources/AWSLambdaRuntime/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntime/LambdaContext.swift
@@ -15,7 +15,6 @@
 
 import Logging
 import NIOCore
-import ServiceContextModule
 
 // MARK: - Client Context
 
@@ -241,39 +240,5 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             deadline: LambdaClock().now.advanced(by: timeout),
             logger: logger
         )
-    }
-}
-
-// MARK: - ServiceContext integration
-
-/// A ``ServiceContextKey`` for the AWS X-Ray trace ID.
-///
-/// This allows downstream libraries that depend on `swift-service-context`
-/// (but not on `AWSLambdaRuntime`) to access the current trace ID via
-/// `ServiceContext.current?.traceID`.
-private enum LambdaTraceIDKey: ServiceContextKey {
-    typealias Value = String
-    static var nameOverride: String? { AmazonHeaders.traceID }
-}
-
-extension ServiceContext {
-    /// The AWS X-Ray trace ID for the current Lambda invocation, if available.
-    ///
-    /// This value is automatically set by the Lambda runtime before calling the handler
-    /// and is available to all code running within the handler's async task tree.
-    ///
-    /// Downstream libraries can read this without depending on `AWSLambdaRuntime`:
-    /// ```swift
-    /// if let traceID = ServiceContext.current?.traceID {
-    ///     // propagate traceID to outgoing HTTP requests, etc.
-    /// }
-    /// ```
-    public var traceID: String? {
-        get {
-            self[LambdaTraceIDKey.self]
-        }
-        set {
-            self[LambdaTraceIDKey.self] = newValue
-        }
     }
 }

--- a/Sources/AWSLambdaRuntime/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntime/LambdaContext.swift
@@ -222,6 +222,26 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         "\(Self.self)(requestID: \(self.requestID), traceID: \(self.traceID), invokedFunctionARN: \(self.invokedFunctionARN), cognitoIdentity: \(self.cognitoIdentity ?? "nil"), clientContext: \(String(describing: self.clientContext)), deadline: \(self.deadline))"
     }
 
+    // MARK: - TaskLocal Trace ID
+
+    /// The trace ID for the current Lambda invocation, available via Swift's `TaskLocal` mechanism.
+    ///
+    /// This enables OpenTelemetry instrumentation and other tracing libraries to discover
+    /// the current invocation's trace ID without requiring an explicit `LambdaContext` reference.
+    /// The value is automatically set by the runtime before calling the handler and is available
+    /// to all code running within the handler's async task tree.
+    ///
+    /// Returns `nil` when accessed outside of a Lambda invocation scope.
+    ///
+    /// ```swift
+    /// // Inside a Lambda handler or any code called from it:
+    /// if let traceID = LambdaContext.currentTraceID {
+    ///     // Use traceID for downstream propagation
+    /// }
+    /// ```
+    @TaskLocal
+    public static var currentTraceID: String?
+
     /// This interface is not part of the public API and must not be used by adopters. This API is not part of semver versioning.
     /// The timeout is expressed relative to now
     package static func __forTestsOnly(

--- a/Sources/AWSLambdaRuntime/ServiceContext+TraceId.swift
+++ b/Sources/AWSLambdaRuntime/ServiceContext+TraceId.swift
@@ -1,0 +1,35 @@
+import ServiceContextModule
+
+// MARK: - ServiceContext integration
+
+/// A ``ServiceContextKey`` for the AWS X-Ray trace ID.
+///
+/// This allows downstream libraries that depend on `swift-service-context`
+/// (but not on `AWSLambdaRuntime`) to access the current trace ID via
+/// `ServiceContext.current?.traceID`.
+private enum LambdaTraceIDKey: ServiceContextKey {
+    typealias Value = String
+    static var nameOverride: String? { AmazonHeaders.traceID }
+}
+
+extension ServiceContext {
+    /// The AWS X-Ray trace ID for the current Lambda invocation, if available.
+    ///
+    /// This value is automatically set by the Lambda runtime before calling the handler
+    /// and is available to all code running within the handler's async task tree.
+    ///
+    /// Downstream libraries can read this without depending on `AWSLambdaRuntime`:
+    /// ```swift
+    /// if let traceID = ServiceContext.current?.traceID {
+    ///     // propagate traceID to outgoing HTTP requests, etc.
+    /// }
+    /// ```
+    public var traceID: String? {
+        get {
+            self[LambdaTraceIDKey.self]
+        }
+        set {
+            self[LambdaTraceIDKey.self] = newValue
+        }
+    }
+}

--- a/Sources/AWSLambdaRuntime/ServiceContext+TraceId.swift
+++ b/Sources/AWSLambdaRuntime/ServiceContext+TraceId.swift
@@ -1,3 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright SwiftAWSLambdaRuntime project authors
+// Copyright (c) Amazon.com, Inc. or its affiliates.
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import ServiceContextModule
 
 // MARK: - ServiceContext integration

--- a/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
@@ -123,7 +123,7 @@ struct LambdaTraceIDPropagationTests {
         var ctx = ServiceContext.topLevel
         ctx.traceID = traceID
 
-        await ServiceContext.withValue(ctx) {
+        ServiceContext.withValue(ctx) {
             setenv("_X_AMZN_TRACE_ID", traceID, 1)
             defer { unsetenv("_X_AMZN_TRACE_ID") }
 
@@ -144,7 +144,7 @@ struct LambdaTraceIDPropagationTests {
         var ctx = ServiceContext.topLevel
         ctx.traceID = traceID
 
-        await ServiceContext.withValue(ctx) {
+        ServiceContext.withValue(ctx) {
             #expect(ServiceContext.current?.traceID == traceID)
             #expect(Lambda.env("_X_AMZN_TRACE_ID") == nil)
         }
@@ -187,7 +187,7 @@ struct LambdaTraceIDPropagationTests {
         var ctx = ServiceContext.topLevel
         ctx.traceID = serviceContextTraceID
 
-        await ServiceContext.withValue(ctx) {
+        ServiceContext.withValue(ctx) {
             let lambdaContext = LambdaContext.__forTestsOnly(
                 requestID: "test-request",
                 traceID: instanceTraceID,
@@ -210,7 +210,7 @@ struct LambdaTraceIDPropagationTests {
         var ctx = ServiceContext.topLevel
         ctx.traceID = traceID
 
-        await ServiceContext.withValue(ctx) {
+        ServiceContext.withValue(ctx) {
             let lambdaContext = LambdaContext.__forTestsOnly(
                 requestID: "test-request",
                 traceID: traceID,

--- a/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
@@ -13,6 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ServiceContextModule
 import Testing
 
 @testable import AWSLambdaRuntime
@@ -28,68 +29,78 @@ import Musl
 @Suite("Trace ID Propagation Tests", .serialized)
 struct LambdaTraceIDPropagationTests {
 
-    // MARK: - TaskLocal basic behavior
+    // MARK: - ServiceContext basic behavior
 
-    @Test("currentTraceID returns nil outside invocation scope")
+    @Test("ServiceContext traceID returns nil outside invocation scope")
     @available(LambdaSwift 2.0, *)
-    func currentTraceIDIsNilOutsideScope() async {
-        #expect(LambdaContext.currentTraceID == nil)
+    func traceIDIsNilOutsideScope() async {
+        #expect(ServiceContext.current?.traceID == nil)
     }
 
-    @Test("currentTraceID returns value inside withValue scope")
+    @Test("ServiceContext traceID returns value inside withValue scope")
     @available(LambdaSwift 2.0, *)
-    func currentTraceIDAvailableInsideScope() async {
+    func traceIDAvailableInsideScope() async {
         let expectedTraceID = "Root=1-abc-def123;Sampled=1"
 
-        await LambdaContext.$currentTraceID.withValue(expectedTraceID) {
-            #expect(LambdaContext.currentTraceID == expectedTraceID)
+        var context = ServiceContext.topLevel
+        context.traceID = expectedTraceID
+
+        ServiceContext.withValue(context) {
+            #expect(ServiceContext.current?.traceID == expectedTraceID)
         }
 
         // After scope ends, should be nil again
-        #expect(LambdaContext.currentTraceID == nil)
+        #expect(ServiceContext.current?.traceID == nil)
     }
 
-    @Test("currentTraceID is isolated between concurrent tasks")
+    @Test("ServiceContext traceID is isolated between concurrent tasks")
     @available(LambdaSwift 2.0, *)
-    func currentTraceIDIsolatedBetweenConcurrentTasks() async {
+    func traceIDIsolatedBetweenConcurrentTasks() async {
         let traceID1 = "Root=1-aaa-111;Sampled=1"
         let traceID2 = "Root=1-bbb-222;Sampled=1"
         let traceID3 = "Root=1-ccc-333;Sampled=1"
 
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
-                await LambdaContext.$currentTraceID.withValue(traceID1) {
-                    // Simulate some async work
+                var ctx = ServiceContext.topLevel
+                ctx.traceID = traceID1
+                await ServiceContext.withValue(ctx) {
                     try? await Task.sleep(for: .milliseconds(50))
-                    #expect(LambdaContext.currentTraceID == traceID1)
+                    #expect(ServiceContext.current?.traceID == traceID1)
                 }
             }
             group.addTask {
-                await LambdaContext.$currentTraceID.withValue(traceID2) {
+                var ctx = ServiceContext.topLevel
+                ctx.traceID = traceID2
+                await ServiceContext.withValue(ctx) {
                     try? await Task.sleep(for: .milliseconds(50))
-                    #expect(LambdaContext.currentTraceID == traceID2)
+                    #expect(ServiceContext.current?.traceID == traceID2)
                 }
             }
             group.addTask {
-                await LambdaContext.$currentTraceID.withValue(traceID3) {
+                var ctx = ServiceContext.topLevel
+                ctx.traceID = traceID3
+                await ServiceContext.withValue(ctx) {
                     try? await Task.sleep(for: .milliseconds(50))
-                    #expect(LambdaContext.currentTraceID == traceID3)
+                    #expect(ServiceContext.current?.traceID == traceID3)
                 }
             }
             await group.waitForAll()
         }
     }
 
-    @Test("currentTraceID propagates to child tasks")
+    @Test("ServiceContext traceID propagates to child tasks")
     @available(LambdaSwift 2.0, *)
-    func currentTraceIDPropagatesToChildTasks() async {
+    func traceIDPropagatesToChildTasks() async {
         let expectedTraceID = "Root=1-child-test;Sampled=1"
 
-        await LambdaContext.$currentTraceID.withValue(expectedTraceID) {
-            // Child task should inherit the TaskLocal value
+        var ctx = ServiceContext.topLevel
+        ctx.traceID = expectedTraceID
+
+        await ServiceContext.withValue(ctx) {
             await withTaskGroup(of: String?.self) { group in
                 group.addTask {
-                    LambdaContext.currentTraceID
+                    ServiceContext.current?.traceID
                 }
                 for await childTraceID in group {
                     #expect(childTraceID == expectedTraceID)
@@ -109,17 +120,17 @@ struct LambdaTraceIDPropagationTests {
         unsetenv("_X_AMZN_TRACE_ID")
         #expect(Lambda.env("_X_AMZN_TRACE_ID") == nil)
 
-        // Simulate what the run loop does in single-concurrency mode
-        await LambdaContext.$currentTraceID.withValue(traceID) {
+        var ctx = ServiceContext.topLevel
+        ctx.traceID = traceID
+
+        await ServiceContext.withValue(ctx) {
             setenv("_X_AMZN_TRACE_ID", traceID, 1)
             defer { unsetenv("_X_AMZN_TRACE_ID") }
 
-            // During handler execution, env var should be set
             #expect(Lambda.env("_X_AMZN_TRACE_ID") == traceID)
-            #expect(LambdaContext.currentTraceID == traceID)
+            #expect(ServiceContext.current?.traceID == traceID)
         }
 
-        // After scope ends, env var should be cleared
         #expect(Lambda.env("_X_AMZN_TRACE_ID") == nil)
     }
 
@@ -128,40 +139,37 @@ struct LambdaTraceIDPropagationTests {
     func envVarNotSetInMultiConcurrency() async {
         let traceID = "Root=1-multi-test;Sampled=1"
 
-        // Ensure it's not set before
         unsetenv("_X_AMZN_TRACE_ID")
 
-        // Simulate what the run loop does in multi-concurrency mode (isSingleConcurrencyMode = false)
-        // The env var should NOT be set, only the TaskLocal
-        await LambdaContext.$currentTraceID.withValue(traceID) {
-            // In multi-concurrency mode, we skip setenv entirely
-            // TaskLocal should still work
-            #expect(LambdaContext.currentTraceID == traceID)
-            // Env var should NOT be set
+        var ctx = ServiceContext.topLevel
+        ctx.traceID = traceID
+
+        await ServiceContext.withValue(ctx) {
+            #expect(ServiceContext.current?.traceID == traceID)
             #expect(Lambda.env("_X_AMZN_TRACE_ID") == nil)
         }
     }
 
     // MARK: - Background task propagation
 
-    @Test("currentTraceID remains available during simulated background work")
+    @Test("ServiceContext traceID remains available during simulated background work")
     @available(LambdaSwift 2.0, *)
-    func currentTraceIDAvailableDuringBackgroundWork() async {
+    func traceIDAvailableDuringBackgroundWork() async {
         let traceID = "Root=1-background-test;Sampled=1"
 
-        await LambdaContext.$currentTraceID.withValue(traceID) {
-            // Simulate sending response (the trace ID should still be available after)
-            #expect(LambdaContext.currentTraceID == traceID)
+        var ctx = ServiceContext.topLevel
+        ctx.traceID = traceID
 
-            // Simulate background work after response
+        await ServiceContext.withValue(ctx) {
+            #expect(ServiceContext.current?.traceID == traceID)
+
             try? await Task.sleep(for: .milliseconds(10))
-            #expect(LambdaContext.currentTraceID == traceID)
+            #expect(ServiceContext.current?.traceID == traceID)
 
-            // Even deeper async work
             await withTaskGroup(of: Void.self) { group in
                 group.addTask {
                     try? await Task.sleep(for: .milliseconds(10))
-                    #expect(LambdaContext.currentTraceID == traceID)
+                    #expect(ServiceContext.current?.traceID == traceID)
                 }
                 await group.waitForAll()
             }
@@ -170,14 +178,17 @@ struct LambdaTraceIDPropagationTests {
 
     // MARK: - Coexistence with instance property
 
-    @Test("TaskLocal currentTraceID and instance traceID coexist independently")
+    @Test("ServiceContext traceID and LambdaContext instance traceID coexist independently")
     @available(LambdaSwift 2.0, *)
-    func taskLocalAndInstancePropertyCoexist() async {
-        let taskLocalTraceID = "Root=1-tasklocal;Sampled=1"
+    func serviceContextAndInstancePropertyCoexist() async {
+        let serviceContextTraceID = "Root=1-tasklocal;Sampled=1"
         let instanceTraceID = "Root=1-instance;Sampled=0"
 
-        await LambdaContext.$currentTraceID.withValue(taskLocalTraceID) {
-            let context = LambdaContext.__forTestsOnly(
+        var ctx = ServiceContext.topLevel
+        ctx.traceID = serviceContextTraceID
+
+        await ServiceContext.withValue(ctx) {
+            let lambdaContext = LambdaContext.__forTestsOnly(
                 requestID: "test-request",
                 traceID: instanceTraceID,
                 tenantID: nil,
@@ -186,21 +197,21 @@ struct LambdaTraceIDPropagationTests {
                 logger: .init(label: "test")
             )
 
-            // Instance property returns its own value
-            #expect(context.traceID == instanceTraceID)
-            // TaskLocal returns the TaskLocal value
-            #expect(LambdaContext.currentTraceID == taskLocalTraceID)
+            #expect(lambdaContext.traceID == instanceTraceID)
+            #expect(ServiceContext.current?.traceID == serviceContextTraceID)
         }
     }
 
-    @Test("TaskLocal currentTraceID and instance traceID match when set from the same source")
+    @Test("ServiceContext traceID and LambdaContext instance traceID match when set from the same source")
     @available(LambdaSwift 2.0, *)
-    func taskLocalAndInstanceTraceIDMatchFromSameSource() async {
-        // Simulates what the run loop does: both are set from invocation.metadata.traceID
+    func serviceContextAndInstanceTraceIDMatchFromSameSource() async {
         let traceID = "Root=1-65af3dc0-abc123def456;Sampled=1"
 
-        await LambdaContext.$currentTraceID.withValue(traceID) {
-            let context = LambdaContext.__forTestsOnly(
+        var ctx = ServiceContext.topLevel
+        ctx.traceID = traceID
+
+        await ServiceContext.withValue(ctx) {
+            let lambdaContext = LambdaContext.__forTestsOnly(
                 requestID: "test-request",
                 traceID: traceID,
                 tenantID: nil,
@@ -209,7 +220,7 @@ struct LambdaTraceIDPropagationTests {
                 logger: .init(label: "test")
             )
 
-            #expect(context.traceID == LambdaContext.currentTraceID)
+            #expect(lambdaContext.traceID == ServiceContext.current?.traceID)
         }
     }
 }

--- a/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
@@ -192,4 +192,24 @@ struct LambdaTraceIDPropagationTests {
             #expect(LambdaContext.currentTraceID == taskLocalTraceID)
         }
     }
+
+    @Test("TaskLocal currentTraceID and instance traceID match when set from the same source")
+    @available(LambdaSwift 2.0, *)
+    func taskLocalAndInstanceTraceIDMatchFromSameSource() async {
+        // Simulates what the run loop does: both are set from invocation.metadata.traceID
+        let traceID = "Root=1-65af3dc0-abc123def456;Sampled=1"
+
+        await LambdaContext.$currentTraceID.withValue(traceID) {
+            let context = LambdaContext.__forTestsOnly(
+                requestID: "test-request",
+                traceID: traceID,
+                tenantID: nil,
+                invokedFunctionARN: "arn:aws:lambda:us-east-1:123456789:function:test",
+                timeout: .seconds(30),
+                logger: .init(label: "test")
+            )
+
+            #expect(context.traceID == LambdaContext.currentTraceID)
+        }
+    }
 }

--- a/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright SwiftAWSLambdaRuntime project authors
+// Copyright (c) Amazon.com, Inc. or its affiliates.
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import AWSLambdaRuntime
+
+#if os(macOS)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+@Suite("Trace ID Propagation Tests")
+struct LambdaTraceIDPropagationTests {
+
+    // MARK: - TaskLocal basic behavior
+
+    @Test("currentTraceID returns nil outside invocation scope")
+    @available(LambdaSwift 2.0, *)
+    func currentTraceIDIsNilOutsideScope() async {
+        #expect(LambdaContext.currentTraceID == nil)
+    }
+
+    @Test("currentTraceID returns value inside withValue scope")
+    @available(LambdaSwift 2.0, *)
+    func currentTraceIDAvailableInsideScope() async {
+        let expectedTraceID = "Root=1-abc-def123;Sampled=1"
+
+        await LambdaContext.$currentTraceID.withValue(expectedTraceID) {
+            #expect(LambdaContext.currentTraceID == expectedTraceID)
+        }
+
+        // After scope ends, should be nil again
+        #expect(LambdaContext.currentTraceID == nil)
+    }
+
+    @Test("currentTraceID is isolated between concurrent tasks")
+    @available(LambdaSwift 2.0, *)
+    func currentTraceIDIsolatedBetweenConcurrentTasks() async {
+        let traceID1 = "Root=1-aaa-111;Sampled=1"
+        let traceID2 = "Root=1-bbb-222;Sampled=1"
+        let traceID3 = "Root=1-ccc-333;Sampled=1"
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                await LambdaContext.$currentTraceID.withValue(traceID1) {
+                    // Simulate some async work
+                    try? await Task.sleep(for: .milliseconds(50))
+                    #expect(LambdaContext.currentTraceID == traceID1)
+                }
+            }
+            group.addTask {
+                await LambdaContext.$currentTraceID.withValue(traceID2) {
+                    try? await Task.sleep(for: .milliseconds(50))
+                    #expect(LambdaContext.currentTraceID == traceID2)
+                }
+            }
+            group.addTask {
+                await LambdaContext.$currentTraceID.withValue(traceID3) {
+                    try? await Task.sleep(for: .milliseconds(50))
+                    #expect(LambdaContext.currentTraceID == traceID3)
+                }
+            }
+            await group.waitForAll()
+        }
+    }
+
+    @Test("currentTraceID propagates to child tasks")
+    @available(LambdaSwift 2.0, *)
+    func currentTraceIDPropagatesToChildTasks() async {
+        let expectedTraceID = "Root=1-child-test;Sampled=1"
+
+        await LambdaContext.$currentTraceID.withValue(expectedTraceID) {
+            // Child task should inherit the TaskLocal value
+            await withTaskGroup(of: String?.self) { group in
+                group.addTask {
+                    LambdaContext.currentTraceID
+                }
+                for await childTraceID in group {
+                    #expect(childTraceID == expectedTraceID)
+                }
+            }
+        }
+    }
+
+    // MARK: - Environment variable behavior
+
+    @Test("_X_AMZN_TRACE_ID env var is set and cleared in single-concurrency simulation")
+    @available(LambdaSwift 2.0, *)
+    func envVarSetAndClearedInSingleConcurrency() async {
+        let traceID = "Root=1-envvar-test;Sampled=1"
+
+        // Ensure it's not set before
+        unsetenv("_X_AMZN_TRACE_ID")
+        #expect(Lambda.env("_X_AMZN_TRACE_ID") == nil)
+
+        // Simulate what the run loop does in single-concurrency mode
+        await LambdaContext.$currentTraceID.withValue(traceID) {
+            setenv("_X_AMZN_TRACE_ID", traceID, 1)
+            defer { unsetenv("_X_AMZN_TRACE_ID") }
+
+            // During handler execution, env var should be set
+            #expect(Lambda.env("_X_AMZN_TRACE_ID") == traceID)
+            #expect(LambdaContext.currentTraceID == traceID)
+        }
+
+        // After scope ends, env var should be cleared
+        #expect(Lambda.env("_X_AMZN_TRACE_ID") == nil)
+    }
+
+    @Test("_X_AMZN_TRACE_ID env var is NOT set in multi-concurrency simulation")
+    @available(LambdaSwift 2.0, *)
+    func envVarNotSetInMultiConcurrency() async {
+        let traceID = "Root=1-multi-test;Sampled=1"
+
+        // Ensure it's not set before
+        unsetenv("_X_AMZN_TRACE_ID")
+
+        // Simulate what the run loop does in multi-concurrency mode (isSingleConcurrencyMode = false)
+        // The env var should NOT be set, only the TaskLocal
+        await LambdaContext.$currentTraceID.withValue(traceID) {
+            // In multi-concurrency mode, we skip setenv entirely
+            // TaskLocal should still work
+            #expect(LambdaContext.currentTraceID == traceID)
+            // Env var should NOT be set
+            #expect(Lambda.env("_X_AMZN_TRACE_ID") == nil)
+        }
+    }
+
+    // MARK: - Background task propagation
+
+    @Test("currentTraceID remains available during simulated background work")
+    @available(LambdaSwift 2.0, *)
+    func currentTraceIDAvailableDuringBackgroundWork() async {
+        let traceID = "Root=1-background-test;Sampled=1"
+
+        await LambdaContext.$currentTraceID.withValue(traceID) {
+            // Simulate sending response (the trace ID should still be available after)
+            #expect(LambdaContext.currentTraceID == traceID)
+
+            // Simulate background work after response
+            try? await Task.sleep(for: .milliseconds(10))
+            #expect(LambdaContext.currentTraceID == traceID)
+
+            // Even deeper async work
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try? await Task.sleep(for: .milliseconds(10))
+                    #expect(LambdaContext.currentTraceID == traceID)
+                }
+                await group.waitForAll()
+            }
+        }
+    }
+
+    // MARK: - Coexistence with instance property
+
+    @Test("TaskLocal currentTraceID and instance traceID coexist independently")
+    @available(LambdaSwift 2.0, *)
+    func taskLocalAndInstancePropertyCoexist() async {
+        let taskLocalTraceID = "Root=1-tasklocal;Sampled=1"
+        let instanceTraceID = "Root=1-instance;Sampled=0"
+
+        await LambdaContext.$currentTraceID.withValue(taskLocalTraceID) {
+            let context = LambdaContext.__forTestsOnly(
+                requestID: "test-request",
+                traceID: instanceTraceID,
+                tenantID: nil,
+                invokedFunctionARN: "arn:aws:lambda:us-east-1:123456789:function:test",
+                timeout: .seconds(30),
+                logger: .init(label: "test")
+            )
+
+            // Instance property returns its own value
+            #expect(context.traceID == instanceTraceID)
+            // TaskLocal returns the TaskLocal value
+            #expect(LambdaContext.currentTraceID == taskLocalTraceID)
+        }
+    }
+}

--- a/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaTraceIDPropagationTests.swift
@@ -25,7 +25,7 @@ import Glibc
 import Musl
 #endif
 
-@Suite("Trace ID Propagation Tests")
+@Suite("Trace ID Propagation Tests", .serialized)
 struct LambdaTraceIDPropagationTests {
 
     // MARK: - TaskLocal basic behavior


### PR DESCRIPTION
## Issue #
https://github.com/awslabs/swift-aws-lambda-runtime/issues/633

## Description of changes

(read original PR description below) 

Updated from the initial PR — based on review feedback, the trace ID propagation has been reworked to use `ServiceContext` from [swift-service-context](https://github.com/apple/swift-service-context) instead of a Lambda-specific `@TaskLocal`.

The trace ID from AWS wasn't being propagated in a way that's accessible to the full async task tree. Tracing libraries like OpenTelemetry need the trace ID without requiring an explicit `LambdaContext` reference, and the old approach of only setting the `_X_AMZN_TRACE_ID` environment variable doesn't work safely in multi-concurrency mode since env vars are process-global.

This change propagates the trace ID via `ServiceContext.current`, the standard context propagation mechanism in the Swift server ecosystem. The runtime sets `ServiceContext.current?.traceID` before calling the handler, making it automatically available to all code in the handler's async task tree — including downstream libraries that have no dependency on `AWSLambdaRuntime`.

A `ServiceContextKey` (`LambdaTraceIDKey`) is defined with a `public traceID` accessor on `ServiceContext`, so any library depending only on swift-service-context can read the trace ID:

```swift
import ServiceContextModule

if let traceID = ServiceContext.current?.traceID {
    // propagate to outgoing requests
}
```

In single-concurrency mode, the runtime still sets and clears the `_X_AMZN_TRACE_ID` env var for backward compatibility with legacy tooling. In multi-concurrency mode, only `ServiceContext` is used to avoid races between concurrent invocations.

The `runLoop` function accepts an `isSingleConcurrencyMode` flag so it knows which strategy to use. Call sites in `LambdaRuntime` and `LambdaManagedRuntime` pass the appropriate value.

A "Trace ID Propagation" section has been added to the README documenting both access patterns (from a handler via `context.traceID`, and from downstream libraries via `ServiceContext)`.

### New/existing dependencies

Added swift-service-context (1.3.0+) as a new dependency of the `AWSLambdaRuntime` target. This is a lightweight package from Apple that provides the standard `ServiceContext` type used across the Swift server ecosystem (swift-distributed-tracing, swift-service-lifecycle, etc.). It has no transitive dependencies.

### Conventional Commits
feat: propagate trace ID via ServiceContext for ecosystem-wide access

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---
Original PR description for history
---

The trace ID from AWS wasn't being propagated in a way that's accessible to the full async task tree. Tracing libraries like OpenTelemetry need the trace ID without requiring an explicit `LambdaContext` reference, and the old approach of only setting the `_X_AMZN_TRACE_ID` environment variable doesn't work safely in multi-concurrency mode since env vars are process-global.

This change adds a `@TaskLocal` static property `LambdaContext.currentTraceID` that the runtime sets before calling the handler. It's automatically available to all code in the handler's async task tree, including child tasks and background work.

In single-concurrency mode, the runtime still sets and clears the `_X_AMZN_TRACE_ID` env var for backward compatibility with legacy tooling. In multi-concurrency mode, only the TaskLocal is used to avoid races between concurrent invocations.

The `runLoop` function now accepts an `isSingleConcurrencyMode` flag so it knows which strategy to use. Call sites in `LambdaRuntime` and `LambdaManagedRuntime` pass the appropriate value.

Tests cover TaskLocal scoping, child task inheritance, concurrent isolation between tasks, env var lifecycle in both modes, and coexistence of the static TaskLocal with the existing instance `traceID` property.

## New/existing dependencies impact assessment, if applicable

No new dependencies were added to this change.

## Conventional Commits

`feat: propagate trace ID via TaskLocal for async task tree access`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
