### PR TITLE
propagate isSingleConcurrencyMode from Lambda to LambadRuntime 

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -36,7 +36,7 @@ public enum Lambda {
         *,
         deprecated,
         message:
-            "This method will be removed in a future major version update. Use runLoop(runtimeClient:handler:loggingConfiguration:logger:) instead."
+            "This method will be removed in a future major version update. Use runLoop(runtimeClient:handler:loggingConfiguration:logger:isSingleConcurrencyMode:) instead."
     )
     @inlinable
     package static func runLoop<RuntimeClient: LambdaRuntimeClientProtocol, Handler>(
@@ -48,7 +48,30 @@ public enum Lambda {
             runtimeClient: runtimeClient,
             handler: handler,
             loggingConfiguration: LoggingConfiguration(logger: logger),
-            logger: logger
+            logger: logger,
+            isSingleConcurrencyMode: true
+        )
+    }
+
+    @available(
+        *,
+        deprecated,
+        message:
+            "This method will be removed in a future major version update. Use runLoop(runtimeClient:handler:loggingConfiguration:logger:isSingleConcurrencyMode:) instead."
+    )
+    @inlinable
+    package static func runLoop<RuntimeClient: LambdaRuntimeClientProtocol, Handler>(
+        runtimeClient: RuntimeClient,
+        handler: Handler,
+        loggingConfiguration: LoggingConfiguration,
+        logger: Logger
+    ) async throws where Handler: StreamingLambdaHandler {
+        try await self.runLoop(
+            runtimeClient: runtimeClient,
+            handler: handler,
+            loggingConfiguration: LoggingConfiguration(logger: logger),
+            logger: logger,
+            isSingleConcurrencyMode: true
         )
     }
 
@@ -57,7 +80,8 @@ public enum Lambda {
         runtimeClient: RuntimeClient,
         handler: Handler,
         loggingConfiguration: LoggingConfiguration,
-        logger: Logger
+        logger: Logger,
+        isSingleConcurrencyMode: Bool
     ) async throws where Handler: StreamingLambdaHandler {
         var handler = handler
 

--- a/Sources/AWSLambdaRuntime/ManagedRuntime/LambdaManagedRuntime.swift
+++ b/Sources/AWSLambdaRuntime/ManagedRuntime/LambdaManagedRuntime.swift
@@ -96,7 +96,8 @@ public final class LambdaManagedRuntime<Handler>: Sendable where Handler: Stream
                         handler: self.handler,
                         eventLoop: self.eventLoop,
                         loggingConfiguration: self.loggingConfiguration,
-                        logger: self.logger
+                        logger: self.logger,
+                        isSingleConcurrencyMode: true
                     )
                 } else {
 
@@ -113,7 +114,8 @@ public final class LambdaManagedRuntime<Handler>: Sendable where Handler: Stream
                                     handler: self.handler,
                                     eventLoop: self.eventLoop,
                                     loggingConfiguration: self.loggingConfiguration,
-                                    logger: logger
+                                    logger: logger,
+                                    isSingleConcurrencyMode: false
                                 )
                             }
                         }

--- a/Sources/AWSLambdaRuntime/Runtime/LambdaRuntime.swift
+++ b/Sources/AWSLambdaRuntime/Runtime/LambdaRuntime.swift
@@ -105,7 +105,8 @@ public final class LambdaRuntime<Handler>: Sendable where Handler: StreamingLamb
                     handler: handler,
                     eventLoop: self.eventLoop,
                     loggingConfiguration: self.loggingConfiguration,
-                    logger: self.logger
+                    logger: self.logger,
+                    isSingleConcurrencyMode: true
                 )
 
             } else {
@@ -126,7 +127,8 @@ public final class LambdaRuntime<Handler>: Sendable where Handler: StreamingLamb
         handler: Handler,
         eventLoop: EventLoop,
         loggingConfiguration: LoggingConfiguration,
-        logger: Logger
+        logger: Logger,
+        isSingleConcurrencyMode: Bool
     ) async throws {
 
         let ipAndPort = endpoint.split(separator: ":", maxSplits: 1)
@@ -143,7 +145,8 @@ public final class LambdaRuntime<Handler>: Sendable where Handler: StreamingLamb
                     runtimeClient: runtimeClient,
                     handler: handler,
                     loggingConfiguration: loggingConfiguration,
-                    logger: logger
+                    logger: logger,
+                    isSingleConcurrencyMode: isSingleConcurrencyMode
                 )
             }
         } catch {
@@ -193,7 +196,8 @@ public final class LambdaRuntime<Handler>: Sendable where Handler: StreamingLamb
                     runtimeClient: runtimeClient,
                     handler: handler,
                     loggingConfiguration: loggingConfiguration,
-                    logger: logger
+                    logger: logger,
+                    isSingleConcurrencyMode: true
                 )
             }
         }

--- a/Tests/AWSLambdaRuntimeTests/LambdaRunLoopTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaRunLoopTests.swift
@@ -69,7 +69,8 @@ struct LambdaRunLoopTests {
                     runtimeClient: mockClient,
                     handler: mockEchoHandler,
                     loggingConfiguration: LoggingConfiguration(logger: logger),
-                    logger: logger
+                    logger: logger,
+                    isSingleConcurrencyMode: true
                 )
             }
 
@@ -100,7 +101,8 @@ struct LambdaRunLoopTests {
                     runtimeClient: mockClient,
                     handler: failingHandler,
                     loggingConfiguration: LoggingConfiguration(logger: logger),
-                    logger: logger
+                    logger: logger,
+                    isSingleConcurrencyMode: true
                 )
             }
 


### PR DESCRIPTION
This is an intermediate PR to simplify code review on https://github.com/awslabs/swift-aws-lambda-runtime/pull/652/changes#diff-cec9c6a5c4d161a427105af49fb7e3a990468f324021d4f5e6b2ad14db1a2345

I