### PR TITLE
fix: preserve provided loggingConfiguration in lambda runloop overloa…

### DIFF
--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -69,7 +69,7 @@ public enum Lambda {
         try await self.runLoop(
             runtimeClient: runtimeClient,
             handler: handler,
-            loggingConfiguration: LoggingConfiguration(logger: logger),
+            loggingConfiguration: loggingConfiguration,
             logger: logger,
             isSingleConcurrencyMode: true
         )


### PR DESCRIPTION
…d function

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
The change fixes a regression in the deprecated`Lambda.runLoop(runtimeClient:handler:loggingConfiguration:logger:)` overload. 

The overload was ignoring the caller-provided `loggingConfiguration` and rebuilding a new one from `Logger`.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.