### PR TITLE
chore: remove mock writeStatusAndHeaders shadowing in writer tests

### DIFF
--- a/Tests/AWSLambdaRuntimeTests/LambdaResponseStreamWriter+HeadersTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaResponseStreamWriter+HeadersTests.swift
@@ -542,22 +542,6 @@ final class MockLambdaResponseStreamWriter: LambdaResponseStreamWriter {
     private(set) var isFinished = false
     private(set) var hasCustomHeaders = false
 
-    // Add a JSON string with separator for writeStatusAndHeaders
-    func writeStatusAndHeaders<Response: Encodable>(
-        _ response: Response,
-        encoder: (any LambdaOutputEncoder)? = nil
-    ) async throws {
-        var buffer = ByteBuffer()
-        let jsonString = "{\"statusCode\":200,\"headers\":{\"Content-Type\":\"text/plain\"}}"
-        buffer.writeString(jsonString)
-
-        // Add null byte separator
-        let nullBytes: [UInt8] = [0, 0, 0, 0, 0, 0, 0, 0]
-        buffer.writeBytes(nullBytes)
-
-        try await self.write(buffer, hasCustomHeaders: true)
-    }
-
     func write(_ buffer: ByteBuffer, hasCustomHeaders: Bool = false) async throws {
         writtenBuffers.append(buffer)
         self.hasCustomHeaders = hasCustomHeaders
@@ -585,15 +569,6 @@ final class FailingMockLambdaResponseStreamWriter: LambdaResponseStreamWriter {
 
     init(failOnWriteCall: Int) {
         self.failOnWriteCall = failOnWriteCall
-    }
-
-    func writeStatusAndHeaders<Response: Encodable>(
-        _ response: Response,
-        encoder: (any LambdaOutputEncoder)? = nil
-    ) async throws {
-        var buffer = ByteBuffer()
-        buffer.writeString("{\"statusCode\":200}")
-        try await write(buffer, hasCustomHeaders: true)
     }
 
     func write(_ buffer: ByteBuffer, hasCustomHeaders: Bool = false) async throws {
@@ -698,15 +673,6 @@ final class TrackingLambdaResponseStreamWriter: LambdaResponseStreamWriter {
     private(set) var isFinished = false
     private(set) var hasCustomHeaders = false
 
-    func writeStatusAndHeaders<Response: Encodable>(
-        _ response: Response,
-        encoder: (any LambdaOutputEncoder)? = nil
-    ) async throws {
-        var buffer = ByteBuffer()
-        buffer.writeString("{\"statusCode\":200}")
-        try await write(buffer, hasCustomHeaders: true)
-    }
-
     func write(_ buffer: ByteBuffer, hasCustomHeaders: Bool = false) async throws {
         writeCallCount += 1
         self.hasCustomHeaders = hasCustomHeaders
@@ -732,16 +698,6 @@ final class CustomBehaviorLambdaResponseStreamWriter: LambdaResponseStreamWriter
     private(set) var customBehaviorTriggered = false
     private(set) var isFinished = false
     private(set) var hasCustomHeaders = false
-
-    func writeStatusAndHeaders<Response: Encodable>(
-        _ response: Response,
-        encoder: (any LambdaOutputEncoder)? = nil
-    ) async throws {
-        customBehaviorTriggered = true
-        var buffer = ByteBuffer()
-        buffer.writeString("{\"statusCode\":200}")
-        try await write(buffer, hasCustomHeaders: true)
-    }
 
     func write(_ buffer: ByteBuffer, hasCustomHeaders: Bool = false) async throws {
         // Trigger custom behavior on any write


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Several test mocks in `LambdaResponseStreamWriter+HeadersTests.swift` implemented their own `writeStatusAndHeaders(...)`. 
- This change is required to make the tests validate actual behavior instead of mock-only behavior. 

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.