### PR TITLE
Add logGroupName and logStreamName to LambdaContext

### DIFF
--- a/Sources/AWSLambdaRuntime/Docs.docc/Proposals/0001-v2-api.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Proposals/0001-v2-api.md
@@ -247,12 +247,6 @@ public struct LambdaContext: Sendable {
     ///
     /// - note: The `LogLevel` can be configured using the `LOG_LEVEL` environment variable.
     public var logger: Logger { get }
-
-    /// The name of the Amazon CloudWatch Logs group for the function.
-    public var logGroupName: String { get }
-
-    /// The name of the Amazon CloudWatch Logs stream for the current invocation of the function.
-    public var logStreamName: String { get }
 }
 ```
 

--- a/Sources/AWSLambdaRuntime/Docs.docc/Proposals/0001-v2-api.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Proposals/0001-v2-api.md
@@ -247,6 +247,12 @@ public struct LambdaContext: Sendable {
     ///
     /// - note: The `LogLevel` can be configured using the `LOG_LEVEL` environment variable.
     public var logger: Logger { get }
+
+    /// The name of the Amazon CloudWatch Logs group for the function.
+    public var logGroupName: String { get }
+
+    /// The name of the Amazon CloudWatch Logs stream for the current invocation of the function.
+    public var logStreamName: String { get }
 }
 ```
 

--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -85,6 +85,9 @@ public enum Lambda {
     ) async throws where Handler: StreamingLambdaHandler {
         var handler = handler
 
+        let logGroupName = Lambda.env("AWS_LAMBDA_LOG_GROUP_NAME") ?? ""
+        let logStreamName = Lambda.env("AWS_LAMBDA_LOG_STREAM_NAME") ?? ""
+
         do {
             while !Task.isCancelled {
 
@@ -128,7 +131,9 @@ public enum Lambda {
                             deadline: LambdaClock.Instant(
                                 millisecondsSinceEpoch: invocation.metadata.deadlineInMillisSinceEpoch
                             ),
-                            logger: requestLogger
+                            logger: requestLogger,
+                            logGroupName: logGroupName,
+                            logStreamName: logStreamName
                         )
                     )
                     requestLogger.trace("Handler finished processing invocation")

--- a/Sources/AWSLambdaRuntime/Lambda.swift
+++ b/Sources/AWSLambdaRuntime/Lambda.swift
@@ -85,8 +85,8 @@ public enum Lambda {
     ) async throws where Handler: StreamingLambdaHandler {
         var handler = handler
 
-        let logGroupName = Lambda.env("AWS_LAMBDA_LOG_GROUP_NAME") ?? ""
-        let logStreamName = Lambda.env("AWS_LAMBDA_LOG_STREAM_NAME") ?? ""
+        let logGroupName = Lambda.env("AWS_LAMBDA_LOG_GROUP_NAME")
+        let logStreamName = Lambda.env("AWS_LAMBDA_LOG_STREAM_NAME")
 
         do {
             while !Task.isCancelled {

--- a/Sources/AWSLambdaRuntime/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntime/LambdaContext.swift
@@ -99,6 +99,8 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         let cognitoIdentity: String?
         let clientContext: ClientContext?
         let logger: Logger
+        let logGroupName: String
+        let logStreamName: String
 
         init(
             requestID: String,
@@ -108,7 +110,9 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             deadline: LambdaClock.Instant,
             cognitoIdentity: String?,
             clientContext: ClientContext?,
-            logger: Logger
+            logger: Logger,
+            logGroupName: String,
+            logStreamName: String
         ) {
             self.requestID = requestID
             self.traceID = traceID
@@ -118,6 +122,8 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             self.cognitoIdentity = cognitoIdentity
             self.clientContext = clientContext
             self.logger = logger
+            self.logGroupName = logGroupName
+            self.logStreamName = logStreamName
         }
     }
 
@@ -169,7 +175,7 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         *,
         deprecated,
         message:
-            "This method will be removed in a future major version update. Use init(requestID:traceID:tenantID:invokedFunctionARN:deadline:cognitoIdentity:clientContext:logger) instead."
+            "This method will be removed in a future major version update. Use init(requestID:traceID:tenantID:invokedFunctionARN:deadline:cognitoIdentity:clientContext:logger:logGroupName:logStreamName) instead."
     )
     public init(
         requestID: String,
@@ -199,7 +205,9 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         deadline: LambdaClock.Instant,
         cognitoIdentity: String? = nil,
         clientContext: ClientContext? = nil,
-        logger: Logger
+        logger: Logger,
+        logGroupName: String = "",
+        logStreamName: String = ""
     ) {
         self.storage = _Storage(
             requestID: requestID,
@@ -209,8 +217,20 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             deadline: deadline,
             cognitoIdentity: cognitoIdentity,
             clientContext: clientContext,
-            logger: logger
+            logger: logger,
+            logGroupName: logGroupName,
+            logStreamName: logStreamName
         )
+    }
+
+    /// The name of the Amazon CloudWatch Logs group for the function.
+    public var logGroupName: String {
+        self.storage.logGroupName
+    }
+
+    /// The name of the Amazon CloudWatch Logs stream for the current invocation of the function.
+    public var logStreamName: String {
+        self.storage.logStreamName
     }
 
     public func getRemainingTime() -> Duration {
@@ -230,7 +250,9 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         tenantID: String?,
         invokedFunctionARN: String,
         timeout: Duration,
-        logger: Logger
+        logger: Logger,
+        logGroupName: String = "",
+        logStreamName: String = ""
     ) -> LambdaContext {
         LambdaContext(
             requestID: requestID,
@@ -238,7 +260,9 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             tenantID: tenantID,
             invokedFunctionARN: invokedFunctionARN,
             deadline: LambdaClock().now.advanced(by: timeout),
-            logger: logger
+            logger: logger,
+            logGroupName: logGroupName,
+            logStreamName: logStreamName
         )
     }
 }

--- a/Sources/AWSLambdaRuntime/LambdaContext.swift
+++ b/Sources/AWSLambdaRuntime/LambdaContext.swift
@@ -99,8 +99,8 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         let cognitoIdentity: String?
         let clientContext: ClientContext?
         let logger: Logger
-        let logGroupName: String
-        let logStreamName: String
+        let logGroupName: String?
+        let logStreamName: String?
 
         init(
             requestID: String,
@@ -111,8 +111,8 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
             cognitoIdentity: String?,
             clientContext: ClientContext?,
             logger: Logger,
-            logGroupName: String,
-            logStreamName: String
+            logGroupName: String?,
+            logStreamName: String?
         ) {
             self.requestID = requestID
             self.traceID = traceID
@@ -206,8 +206,8 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         cognitoIdentity: String? = nil,
         clientContext: ClientContext? = nil,
         logger: Logger,
-        logGroupName: String = "",
-        logStreamName: String = ""
+        logGroupName: String? = nil,
+        logStreamName: String? = nil
     ) {
         self.storage = _Storage(
             requestID: requestID,
@@ -224,12 +224,12 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
     }
 
     /// The name of the Amazon CloudWatch Logs group for the function.
-    public var logGroupName: String {
+    public var logGroupName: String? {
         self.storage.logGroupName
     }
 
     /// The name of the Amazon CloudWatch Logs stream for the current invocation of the function.
-    public var logStreamName: String {
+    public var logStreamName: String? {
         self.storage.logStreamName
     }
 
@@ -251,8 +251,8 @@ public struct LambdaContext: CustomDebugStringConvertible, Sendable {
         invokedFunctionARN: String,
         timeout: Duration,
         logger: Logger,
-        logGroupName: String = "",
-        logStreamName: String = ""
+        logGroupName: String? = nil,
+        logStreamName: String? = nil
     ) -> LambdaContext {
         LambdaContext(
             requestID: requestID,

--- a/Tests/AWSLambdaRuntimeTests/LambdaContextTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaContextTests.swift
@@ -136,4 +136,66 @@ struct LambdaContextTests {
         #expect(remainingTime <= Duration.seconds(31), "Remaining time should be approximately 30 seconds")
         #expect(remainingTime >= Duration.seconds(-29), "Remaining time should be approximately -30 seconds")
     }
+
+    @Test("logGroupName returns the value passed at initialization")
+    @available(LambdaSwift 2.0, *)
+    func logGroupNameReturnsInitializedValue() {
+        let context = LambdaContext.__forTestsOnly(
+            requestID: "test-request",
+            traceID: "test-trace",
+            tenantID: nil,
+            invokedFunctionARN: "test-arn",
+            timeout: .seconds(30),
+            logger: Logger(label: "test"),
+            logGroupName: "/aws/lambda/my-function"
+        )
+
+        #expect(context.logGroupName == "/aws/lambda/my-function")
+    }
+
+    @Test("logStreamName returns the value passed at initialization")
+    @available(LambdaSwift 2.0, *)
+    func logStreamNameReturnsInitializedValue() {
+        let context = LambdaContext.__forTestsOnly(
+            requestID: "test-request",
+            traceID: "test-trace",
+            tenantID: nil,
+            invokedFunctionARN: "test-arn",
+            timeout: .seconds(30),
+            logger: Logger(label: "test"),
+            logStreamName: "2024/01/01/[$LATEST]abcdef1234567890"
+        )
+
+        #expect(context.logStreamName == "2024/01/01/[$LATEST]abcdef1234567890")
+    }
+
+    @Test("logGroupName defaults to empty string")
+    @available(LambdaSwift 2.0, *)
+    func logGroupNameDefaultsToEmptyString() {
+        let context = LambdaContext.__forTestsOnly(
+            requestID: "test-request",
+            traceID: "test-trace",
+            tenantID: nil,
+            invokedFunctionARN: "test-arn",
+            timeout: .seconds(30),
+            logger: Logger(label: "test")
+        )
+
+        #expect(context.logGroupName == "")
+    }
+
+    @Test("logStreamName defaults to empty string")
+    @available(LambdaSwift 2.0, *)
+    func logStreamNameDefaultsToEmptyString() {
+        let context = LambdaContext.__forTestsOnly(
+            requestID: "test-request",
+            traceID: "test-trace",
+            tenantID: nil,
+            invokedFunctionARN: "test-arn",
+            timeout: .seconds(30),
+            logger: Logger(label: "test")
+        )
+
+        #expect(context.logStreamName == "")
+    }
 }

--- a/Tests/AWSLambdaRuntimeTests/LambdaContextTests.swift
+++ b/Tests/AWSLambdaRuntimeTests/LambdaContextTests.swift
@@ -169,9 +169,9 @@ struct LambdaContextTests {
         #expect(context.logStreamName == "2024/01/01/[$LATEST]abcdef1234567890")
     }
 
-    @Test("logGroupName defaults to empty string")
+    @Test("logGroupName defaults to nil")
     @available(LambdaSwift 2.0, *)
-    func logGroupNameDefaultsToEmptyString() {
+    func logGroupNameDefaultsToNil() {
         let context = LambdaContext.__forTestsOnly(
             requestID: "test-request",
             traceID: "test-trace",
@@ -181,12 +181,12 @@ struct LambdaContextTests {
             logger: Logger(label: "test")
         )
 
-        #expect(context.logGroupName == "")
+        #expect(context.logGroupName == nil)
     }
 
-    @Test("logStreamName defaults to empty string")
+    @Test("logStreamName defaults to nil")
     @available(LambdaSwift 2.0, *)
-    func logStreamNameDefaultsToEmptyString() {
+    func logStreamNameDefaultsToNil() {
         let context = LambdaContext.__forTestsOnly(
             requestID: "test-request",
             traceID: "test-trace",
@@ -196,6 +196,6 @@ struct LambdaContextTests {
             logger: Logger(label: "test")
         )
 
-        #expect(context.logStreamName == "")
+        #expect(context.logStreamName == nil)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `logGroupName` and `logStreamName` properties to `LambdaContext`, read from `AWS_LAMBDA_LOG_GROUP_NAME` and `AWS_LAMBDA_LOG_STREAM_NAME` environment variables
- Values are read once at runtime initialization (not on every access) and stored as properties, consistent with how other static config is handled
- Matches behavior of Python, Node.js, Java, Go, and other AWS Lambda runtimes

Closes #662

## Test plan
- [x] `swift build` compiles cleanly
- [x] `swift test --filter LambdaContextTests` — all 8 tests pass
- [x] Full test suite (140 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)