### PR TITLE
Use published dependency by default in examples

### DIFF
--- a/.github/workflows/scripts/check-archive-plugin.sh
+++ b/.github/workflows/scripts/check-archive-plugin.sh
@@ -19,6 +19,8 @@ fatal() { error "$@"; exit 1; }
 
 test -n "${EXAMPLE:-}" || fatal "EXAMPLE unset"
 
+SCRIPT_DIR="$(dirname "$0")"
+
 OUTPUT_DIR=.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager
 OUTPUT_FILE=${OUTPUT_DIR}/MyLambda/bootstrap
 ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
@@ -26,7 +28,7 @@ ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
 pushd "Examples/${EXAMPLE}" || exit 1
 
 # Use the local checkout of swift-aws-lambda-runtime instead of the published release
-source "$(dirname "$0")/use-local-deps.sh"
+source "$SCRIPT_DIR/use-local-deps.sh"
 
 # package the example (docker and swift toolchain are installed on the GH runner)
 LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker || exit 1

--- a/.github/workflows/scripts/check-archive-plugin.sh
+++ b/.github/workflows/scripts/check-archive-plugin.sh
@@ -19,17 +19,14 @@ fatal() { error "$@"; exit 1; }
 
 test -n "${EXAMPLE:-}" || fatal "EXAMPLE unset"
 
-SCRIPT_DIR=".github/workflows/scripts"
+# Use the local checkout of swift-aws-lambda-runtime instead of the published release
+.github/workflows/scripts/use-local-deps.sh "Examples/${EXAMPLE}/Package.swift"
 
 OUTPUT_DIR=.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager
 OUTPUT_FILE=${OUTPUT_DIR}/MyLambda/bootstrap
 ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
 
 pushd "Examples/${EXAMPLE}" || exit 1
-
-# Use the local checkout of swift-aws-lambda-runtime instead of the published release
-# shellcheck source=use-local-deps.sh
-source "$SCRIPT_DIR/use-local-deps.sh"
 
 # package the example (docker and swift toolchain are installed on the GH runner)
 LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker || exit 1

--- a/.github/workflows/scripts/check-archive-plugin.sh
+++ b/.github/workflows/scripts/check-archive-plugin.sh
@@ -19,7 +19,7 @@ fatal() { error "$@"; exit 1; }
 
 test -n "${EXAMPLE:-}" || fatal "EXAMPLE unset"
 
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR=".github/workflows/scripts"
 
 OUTPUT_DIR=.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager
 OUTPUT_FILE=${OUTPUT_DIR}/MyLambda/bootstrap
@@ -28,6 +28,7 @@ ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
 pushd "Examples/${EXAMPLE}" || exit 1
 
 # Use the local checkout of swift-aws-lambda-runtime instead of the published release
+# shellcheck source=use-local-deps.sh
 source "$SCRIPT_DIR/use-local-deps.sh"
 
 # package the example (docker and swift toolchain are installed on the GH runner)

--- a/.github/workflows/scripts/check-archive-plugin.sh
+++ b/.github/workflows/scripts/check-archive-plugin.sh
@@ -25,6 +25,9 @@ ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
 
 pushd "Examples/${EXAMPLE}" || exit 1
 
+# Use the local checkout of swift-aws-lambda-runtime instead of the published release
+source "$(dirname "$0")/use-local-deps.sh"
+
 # package the example (docker and swift toolchain are installed on the GH runner)
 LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker || exit 1
 

--- a/.github/workflows/scripts/check-link-foundation.sh
+++ b/.github/workflows/scripts/check-link-foundation.sh
@@ -22,13 +22,10 @@ OUTPUT_DIR=.build/release
 OUTPUT_FILE=${OUTPUT_DIR}/APIGatewayLambda
 LIBS_TO_CHECK="libFoundation.so libFoundationInternationalization.so lib_FoundationICU.so"
 
-SCRIPT_DIR=".github/workflows/scripts"
+# Use the local checkout of swift-aws-lambda-runtime instead of the published release
+.github/workflows/scripts/use-local-deps.sh "Examples/${EXAMPLE}/Package.swift"
 
 pushd Examples/${EXAMPLE} || fatal "Failed to change directory to Examples/${EXAMPLE}."
-
-# Use the local checkout of swift-aws-lambda-runtime instead of the published release
-# shellcheck source=use-local-deps.sh
-source "$SCRIPT_DIR/use-local-deps.sh"
 
 # recompile the example without the --static-swift-stdlib flag
 swift build -c release || fatal "Failed to build the example."

--- a/.github/workflows/scripts/check-link-foundation.sh
+++ b/.github/workflows/scripts/check-link-foundation.sh
@@ -24,6 +24,9 @@ LIBS_TO_CHECK="libFoundation.so libFoundationInternationalization.so lib_Foundat
 
 pushd Examples/${EXAMPLE} || fatal "Failed to change directory to Examples/${EXAMPLE}."
 
+# Use the local checkout of swift-aws-lambda-runtime instead of the published release
+source "$(dirname "$0")/use-local-deps.sh"
+
 # recompile the example without the --static-swift-stdlib flag
 swift build -c release || fatal "Failed to build the example."
 

--- a/.github/workflows/scripts/check-link-foundation.sh
+++ b/.github/workflows/scripts/check-link-foundation.sh
@@ -22,11 +22,12 @@ OUTPUT_DIR=.build/release
 OUTPUT_FILE=${OUTPUT_DIR}/APIGatewayLambda
 LIBS_TO_CHECK="libFoundation.so libFoundationInternationalization.so lib_FoundationICU.so"
 
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR=".github/workflows/scripts"
 
 pushd Examples/${EXAMPLE} || fatal "Failed to change directory to Examples/${EXAMPLE}."
 
 # Use the local checkout of swift-aws-lambda-runtime instead of the published release
+# shellcheck source=use-local-deps.sh
 source "$SCRIPT_DIR/use-local-deps.sh"
 
 # recompile the example without the --static-swift-stdlib flag

--- a/.github/workflows/scripts/check-link-foundation.sh
+++ b/.github/workflows/scripts/check-link-foundation.sh
@@ -22,10 +22,12 @@ OUTPUT_DIR=.build/release
 OUTPUT_FILE=${OUTPUT_DIR}/APIGatewayLambda
 LIBS_TO_CHECK="libFoundation.so libFoundationInternationalization.so lib_FoundationICU.so"
 
+SCRIPT_DIR="$(dirname "$0")"
+
 pushd Examples/${EXAMPLE} || fatal "Failed to change directory to Examples/${EXAMPLE}."
 
 # Use the local checkout of swift-aws-lambda-runtime instead of the published release
-source "$(dirname "$0")/use-local-deps.sh"
+source "$SCRIPT_DIR/use-local-deps.sh"
 
 # recompile the example without the --static-swift-stdlib flag
 swift build -c release || fatal "Failed to build the example."

--- a/.github/workflows/scripts/integration_tests.sh
+++ b/.github/workflows/scripts/integration_tests.sh
@@ -24,13 +24,10 @@ test -n "${SWIFT_VERSION:-}" || fatal "SWIFT_VERSION unset"
 test -n "${COMMAND:-}" || fatal "COMMAND unset"
 test -n "${EXAMPLE:-}" || fatal "EXAMPLE unset"
 
-SCRIPT_DIR=".github/workflows/scripts"
+# Use the local checkout of swift-aws-lambda-runtime instead of the published release
+.github/workflows/scripts/use-local-deps.sh "Examples/$EXAMPLE/Package.swift"
 
 pushd Examples/"$EXAMPLE" > /dev/null
-
-# Use the local checkout of swift-aws-lambda-runtime instead of the published release
-# shellcheck source=use-local-deps.sh
-source "$SCRIPT_DIR/use-local-deps.sh"
 
 log "Running command with Swift $SWIFT_VERSION"
 eval "$COMMAND"

--- a/.github/workflows/scripts/integration_tests.sh
+++ b/.github/workflows/scripts/integration_tests.sh
@@ -24,10 +24,12 @@ test -n "${SWIFT_VERSION:-}" || fatal "SWIFT_VERSION unset"
 test -n "${COMMAND:-}" || fatal "COMMAND unset"
 test -n "${EXAMPLE:-}" || fatal "EXAMPLE unset"
 
+SCRIPT_DIR="$(dirname "$0")"
+
 pushd Examples/"$EXAMPLE" > /dev/null
 
 # Use the local checkout of swift-aws-lambda-runtime instead of the published release
-source "$(dirname "$0")/use-local-deps.sh"
+source "$SCRIPT_DIR/use-local-deps.sh"
 
 log "Running command with Swift $SWIFT_VERSION"
 eval "$COMMAND"

--- a/.github/workflows/scripts/integration_tests.sh
+++ b/.github/workflows/scripts/integration_tests.sh
@@ -24,11 +24,12 @@ test -n "${SWIFT_VERSION:-}" || fatal "SWIFT_VERSION unset"
 test -n "${COMMAND:-}" || fatal "COMMAND unset"
 test -n "${EXAMPLE:-}" || fatal "EXAMPLE unset"
 
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR=".github/workflows/scripts"
 
 pushd Examples/"$EXAMPLE" > /dev/null
 
 # Use the local checkout of swift-aws-lambda-runtime instead of the published release
+# shellcheck source=use-local-deps.sh
 source "$SCRIPT_DIR/use-local-deps.sh"
 
 log "Running command with Swift $SWIFT_VERSION"

--- a/.github/workflows/scripts/integration_tests.sh
+++ b/.github/workflows/scripts/integration_tests.sh
@@ -26,6 +26,9 @@ test -n "${EXAMPLE:-}" || fatal "EXAMPLE unset"
 
 pushd Examples/"$EXAMPLE" > /dev/null
 
+# Use the local checkout of swift-aws-lambda-runtime instead of the published release
+source "$(dirname "$0")/use-local-deps.sh"
+
 log "Running command with Swift $SWIFT_VERSION"
 eval "$COMMAND"
 

--- a/.github/workflows/scripts/use-local-deps.sh
+++ b/.github/workflows/scripts/use-local-deps.sh
@@ -13,17 +13,19 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-# Rewrites Package.swift in the current directory to use the local path dependency
-# instead of the remote URL. This ensures CI tests against the current branch.
+# Rewrites a Package.swift to use the local path dependency instead of the remote URL.
+# This ensures CI tests against the current branch.
 #
-# Usage: source this file or call it from the example directory.
+# Usage: .github/workflows/scripts/use-local-deps.sh <path-to-Package.swift>
 
 set -euo pipefail
 
 log() { printf -- "** %s\n" "$*" >&2; }
 
-log "Switching swift-aws-lambda-runtime dependency to local path"
+PACKAGE_FILE="${1:?Usage: use-local-deps.sh <path-to-Package.swift>}"
+
+log "Switching swift-aws-lambda-runtime dependency to local path in $PACKAGE_FILE"
 sed -i \
   -e 's|// *\.package(name: "swift-aws-lambda-runtime", path: "\.\./\.\.")|.package(name: "swift-aws-lambda-runtime", path: "../..")|' \
   -e 's|\.package(url: "https://github.com/awslabs/swift-aws-lambda-runtime\.git", from: "[^"]*")|// .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "0.0.0")|' \
-  Package.swift
+  "$PACKAGE_FILE"

--- a/.github/workflows/scripts/use-local-deps.sh
+++ b/.github/workflows/scripts/use-local-deps.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftAWSLambdaRuntime open source project
+##
+## Copyright (c) 2017-2024 Apple Inc. and the SwiftAWSLambdaRuntime project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# Rewrites Package.swift in the current directory to use the local path dependency
+# instead of the remote URL. This ensures CI tests against the current branch.
+#
+# Usage: source this file or call it from the example directory.
+
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+
+log "Switching swift-aws-lambda-runtime dependency to local path"
+sed -i \
+  -e 's|// *\.package(name: "swift-aws-lambda-runtime", path: "\.\./\.\.")|.package(name: "swift-aws-lambda-runtime", path: "../..")|' \
+  -e 's|\.package(url: "https://github.com/awslabs/swift-aws-lambda-runtime\.git", from: "[^"]*")|// .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "0.0.0")|' \
+  Package.swift

--- a/Examples/APIGatewayV1/Package.swift
+++ b/Examples/APIGatewayV1/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "APIGatewayLambda", targets: ["APIGatewayLambda"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/APIGatewayV2+LambdaAuthorizer/Package.swift
+++ b/Examples/APIGatewayV2+LambdaAuthorizer/Package.swift
@@ -10,11 +10,10 @@ let package = Package(
         .executable(name: "AuthorizerLambda", targets: ["AuthorizerLambda"]),
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/APIGatewayV2/Package.swift
+++ b/Examples/APIGatewayV2/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "APIGatewayLambda", targets: ["APIGatewayLambda"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/BackgroundTasks/Package.swift
+++ b/Examples/BackgroundTasks/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // For local development, uncomment the line below and comment the remote dependency:
         // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/BackgroundTasks/Package.swift
+++ b/Examples/BackgroundTasks/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "BackgroundTasks", targets: ["BackgroundTasks"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../..")
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/CDK/Package.swift
+++ b/Examples/CDK/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "APIGatewayLambda", targets: ["APIGatewayLambda"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/HelloJSON/Package.swift
+++ b/Examples/HelloJSON/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // For local development, uncomment the line below and comment the remote dependency:
         // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/HelloJSON/Package.swift
+++ b/Examples/HelloJSON/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "HelloJSON", targets: ["HelloJSON"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../..")
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/HelloWorld/Package.swift
+++ b/Examples/HelloWorld/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // For local development, uncomment the line below and comment the remote dependency:
         // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/HelloWorld/Package.swift
+++ b/Examples/HelloWorld/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../..")
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/HelloWorldNoTraits/Package.swift
+++ b/Examples/HelloWorldNoTraits/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // For local development, uncomment the line below and comment the remote dependency:
         // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/HelloWorldNoTraits/Package.swift
+++ b/Examples/HelloWorldNoTraits/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../..")
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/JSONLogging/Package.swift
+++ b/Examples/JSONLogging/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // For local development, uncomment the line below and comment the remote dependency:
         // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/JSONLogging/Package.swift
+++ b/Examples/JSONLogging/Package.swift
@@ -9,13 +9,10 @@ let package = Package(
         .executable(name: "JSONLogging", targets: ["JSONLogging"])
     ],
     dependencies: [
-        // For local development (default)
-        // When using the below line, use LAMBDA_USE_LOCAL_DEPS=../.. for swift package archive command, e.g.
-        // `LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker`
-        .package(name: "swift-aws-lambda-runtime", path: "../..")
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/JSONLogging/README.md
+++ b/Examples/JSONLogging/README.md
@@ -84,7 +84,7 @@ AWS_LAMBDA_LOG_FORMAT=JSON swift run
 
 ```bash
 swift build
-LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker
 ```
 
 The deployment package will be at:

--- a/Examples/ManagedInstances/Package.swift
+++ b/Examples/ManagedInstances/Package.swift
@@ -11,13 +11,10 @@ let package = Package(
         .executable(name: "BackgroundTasks", targets: ["BackgroundTasks"]),
     ],
     dependencies: [
-        // For local development (default)
-        // When using the below line, use LAMBDA_USE_LOCAL_DEPS=../.. for swift package archive command, e.g.
-        // `LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker`
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/ManagedInstances/README.md
+++ b/Examples/ManagedInstances/README.md
@@ -27,11 +27,8 @@ arn:aws:lambda:us-west-2:486652066693:capacity-provider:TestEC2
 ## Deployment
 
 ```bash
-# Build the Swift packages
-# when compiling a standalone or new project
+# Build and package the Swift Lambda function
 swift package archive --allow-network-connections docker 
-# When compiling the example in this repository 
-# LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker 
 
 # Change the values below to match your setup 
 REGION=us-west-2

--- a/Examples/MultiSourceAPI/Package.swift
+++ b/Examples/MultiSourceAPI/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "MultiSourceAPI", targets: ["MultiSourceAPI"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/MultiTenant/Package.swift
+++ b/Examples/MultiTenant/Package.swift
@@ -10,11 +10,10 @@ let package = Package(
         .executable(name: "MultiTenantLocal", targets: ["MultiTenantLocal"]),
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/ResourcesPackaging/Package.swift
+++ b/Examples/ResourcesPackaging/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // For local development, uncomment the line below and comment the remote dependency:
         // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0")
     ],
     targets: [
         .executableTarget(

--- a/Examples/ResourcesPackaging/Package.swift
+++ b/Examples/ResourcesPackaging/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "MyLambda", targets: ["MyLambda"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../..")
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/S3EventNotifier/Package.swift
+++ b/Examples/S3EventNotifier/Package.swift
@@ -5,11 +5,10 @@ let package = Package(
     name: "S3EventNotifier",
     platforms: [.macOS(.v15)],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/S3_AWSSDK/Package.swift
+++ b/Examples/S3_AWSSDK/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "AWSSDKExample", targets: ["AWSSDKExample"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
         .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.0.0"),

--- a/Examples/S3_Soto/Package.swift
+++ b/Examples/S3_Soto/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "SotoExample", targets: ["SotoExample"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
         .package(url: "https://github.com/soto-project/soto.git", from: "7.0.0"),

--- a/Examples/ServiceLifecycle+Postgres/Package.swift
+++ b/Examples/ServiceLifecycle+Postgres/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .macOS(.v15)
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.4.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.30.0"),

--- a/Examples/Streaming+APIGateway/Package.swift
+++ b/Examples/Streaming+APIGateway/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "StreamingNumbers", targets: ["StreamingNumbers"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],
     targets: [

--- a/Examples/Streaming+Codable/Package.swift
+++ b/Examples/Streaming+Codable/Package.swift
@@ -6,11 +6,10 @@ let package = Package(
     name: "StreamingCodable",
     platforms: [.macOS(.v15)],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/Streaming+FunctionUrl/Package.swift
+++ b/Examples/Streaming+FunctionUrl/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "StreamingNumbers", targets: ["StreamingNumbers"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/Testing/Package.swift
+++ b/Examples/Testing/Package.swift
@@ -9,11 +9,10 @@ let package = Package(
         .executable(name: "APIGatewayLambda", targets: ["APIGatewayLambda"])
     ],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../.."),
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../.."),
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
 
         .package(url: "https://github.com/awslabs/swift-aws-lambda-events.git", from: "1.0.0"),
     ],

--- a/Examples/Tutorial/Package.swift
+++ b/Examples/Tutorial/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         // For local development, uncomment the line below and comment the remote dependency:
         // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Examples/Tutorial/Package.swift
+++ b/Examples/Tutorial/Package.swift
@@ -7,11 +7,10 @@ let package = Package(
     name: "Palindrome",
     platforms: [.macOS(.v15)],
     dependencies: [
-        // For local development (default)
-        .package(name: "swift-aws-lambda-runtime", path: "../..")
+        // For local development, uncomment the line below and comment the remote dependency:
+        // .package(name: "swift-aws-lambda-runtime", path: "../..")
 
-        // For standalone usage, comment the line above and uncomment below:
-        // .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.0.0"),
+        .package(url: "https://github.com/awslabs/swift-aws-lambda-runtime.git", from: "2.9.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
## Summary

Examples now default to the published `swift-aws-lambda-runtime` package from GitHub, so they work out of the box when cloned standalone (as described in the READMEs).

CI scripts swap the dependency to the local path (`../..`) before building, ensuring we still test against the current branch.

### Changes

- **`Examples/APIGatewayV2/Package.swift`** — Default to remote URL, local path is commented out with clear instructions.
- **`.github/workflows/scripts/use-local-deps.sh`** (new) — Shared script that rewrites Package.swift to use the local dependency.
- **`integration_tests.sh`**, **`check-archive-plugin.sh`**, **`check-link-foundation.sh`** — Source `use-local-deps.sh` before building.

### Testing

This PR exercises the CI change on the APIGatewayV2 example. Once green, the same pattern will be applied to all other examples.