### PR TITLE
[plugin] Display a warning when compiling on Amazon Linux 2 and optin documentation and examples for Amazon Linux 2023

### DIFF
--- a/.github/workflows/scripts/check-archive-plugin.sh
+++ b/.github/workflows/scripts/check-archive-plugin.sh
@@ -29,7 +29,7 @@ ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
 pushd "Examples/${EXAMPLE}" || exit 1
 
 # package the example (docker and swift toolchain are installed on the GH runner)
-LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker || exit 1
+LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023 || exit 1
 
 # did the plugin generated a Linux binary?
 [ -f "${OUTPUT_FILE}" ]

--- a/.github/workflows/scripts/check-archive-plugin.sh
+++ b/.github/workflows/scripts/check-archive-plugin.sh
@@ -29,7 +29,7 @@ ZIP_FILE=${OUTPUT_DIR}/MyLambda/MyLambda.zip
 pushd "Examples/${EXAMPLE}" || exit 1
 
 # package the example (docker and swift toolchain are installed on the GH runner)
-LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023 || exit 1
+LAMBDA_USE_LOCAL_DEPS=../.. swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023 || exit 1
 
 # did the plugin generated a Linux binary?
 [ -f "${OUTPUT_FILE}" ]

--- a/Examples/APIGatewayV1/README.md
+++ b/Examples/APIGatewayV1/README.md
@@ -25,7 +25,7 @@ To build the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 

--- a/Examples/APIGatewayV1/template.yaml
+++ b/Examples/APIGatewayV1/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/APIGatewayLambda/APIGatewayLambda.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/APIGatewayV2+LambdaAuthorizer/README.md
+++ b/Examples/APIGatewayV2+LambdaAuthorizer/README.md
@@ -19,7 +19,7 @@ To build the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there are two ZIP files ready to deploy, one for the authorizer function and one for the business function.

--- a/Examples/APIGatewayV2+LambdaAuthorizer/template.yaml
+++ b/Examples/APIGatewayV2+LambdaAuthorizer/template.yaml
@@ -50,7 +50,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/APIGatewayLambda/APIGatewayLambda.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64
@@ -75,7 +75,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/AuthorizerLambda/AuthorizerLambda.zip
       Timeout: 29  # max 29 seconds for Lambda authorizers
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/APIGatewayV2/README.md
+++ b/Examples/APIGatewayV2/README.md
@@ -25,7 +25,7 @@ To build the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 

--- a/Examples/APIGatewayV2/template.yaml
+++ b/Examples/APIGatewayV2/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/APIGatewayLambda/APIGatewayLambda.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/BackgroundTasks/README.md
+++ b/Examples/BackgroundTasks/README.md
@@ -25,7 +25,7 @@ Once the struct is created and the `handle(...)` method is defined, the sample c
 To build & archive the package, type the following commands.
 
 ```bash
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 
@@ -42,7 +42,7 @@ AWS_ACCOUNT_ID=012345678901
 aws lambda create-function \
 --function-name BackgroundTasks \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/BackgroundTasks/BackgroundTasks.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided  \
 --architectures arm64 \
 --role arn:aws:iam::${AWS_ACCOUNT_ID}:role/lambda_basic_execution \

--- a/Examples/CDK/README.md
+++ b/Examples/CDK/README.md
@@ -12,7 +12,7 @@ To build the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 

--- a/Examples/HelloJSON/README.md
+++ b/Examples/HelloJSON/README.md
@@ -21,7 +21,7 @@ The function return value will be encoded to a `HelloResponse` as your Lambda fu
 To build & archive the package, type the following commands.
 
 ```bash
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 
@@ -38,7 +38,7 @@ AWS_ACCOUNT_ID=012345678901
 aws lambda create-function \
 --function-name HelloJSON \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/HelloJSON/HelloJSON.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided  \
 --architectures arm64 \
 --role arn:aws:iam::${AWS_ACCOUNT_ID}:role/lambda_basic_execution

--- a/Examples/HelloWorld/README.md
+++ b/Examples/HelloWorld/README.md
@@ -47,7 +47,7 @@ To build & archive the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 
@@ -61,7 +61,7 @@ Here is how to deploy using the `aws` command line.
 aws lambda create-function \
 --function-name MyLambda \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided  \
 --architectures arm64 \
 --role arn:aws:iam::<YOUR_ACCOUNT_ID>:role/lambda_basic_execution

--- a/Examples/HelloWorldNoTraits/README.md
+++ b/Examples/HelloWorldNoTraits/README.md
@@ -53,7 +53,7 @@ To build & archive the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 
@@ -67,7 +67,7 @@ Here is how to deploy using the `aws` command line.
 aws lambda create-function \
 --function-name MyLambda \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided  \
 --architectures arm64 \
 --role arn:aws:iam::<YOUR_ACCOUNT_ID>:role/lambda_basic_execution

--- a/Examples/HummingbirdLambda/README.md
+++ b/Examples/HummingbirdLambda/README.md
@@ -18,7 +18,7 @@ To build the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 

--- a/Examples/HummingbirdLambda/template.yaml
+++ b/Examples/HummingbirdLambda/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/HBLambda/HBLambda.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/JSONLogging/README.md
+++ b/Examples/JSONLogging/README.md
@@ -84,7 +84,7 @@ AWS_LAMBDA_LOG_FORMAT=JSON swift run
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 The deployment package will be at:

--- a/Examples/ManagedInstances/README.md
+++ b/Examples/ManagedInstances/README.md
@@ -28,7 +28,7 @@ arn:aws:lambda:us-west-2:486652066693:capacity-provider:TestEC2
 
 ```bash
 # Build and package the Swift Lambda function
-swift package archive --allow-network-connections docker 
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 
 # Change the values below to match your setup 
 REGION=us-west-2

--- a/Examples/MultiSourceAPI/README.md
+++ b/Examples/MultiSourceAPI/README.md
@@ -13,7 +13,7 @@ Based on the successfully decoded type, it returns an appropriate response.
 ## Building
 
 ```bash
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 ## Deploying

--- a/Examples/MultiSourceAPI/template.yaml
+++ b/Examples/MultiSourceAPI/template.yaml
@@ -8,7 +8,7 @@ Resources:
     Properties:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MultiSourceAPI/MultiSourceAPI.zip
       Handler: provided
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Architectures:
         - arm64
       MemorySize: 256

--- a/Examples/MultiTenant/README.md
+++ b/Examples/MultiTenant/README.md
@@ -166,7 +166,7 @@ requestParameters:
 
 1. **Build the Lambda function**:
    ```bash
-   swift package archive --allow-network-connections docker
+   swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
    ```
 
 2. **Deploy using SAM**:

--- a/Examples/ResourcesPackaging/README.md
+++ b/Examples/ResourcesPackaging/README.md
@@ -49,7 +49,7 @@ curl -d '"hello"' http://127.0.0.1:7000/invoke
 To build & archive the package, type the following commands.
 
 ```bash
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 
@@ -63,7 +63,7 @@ Here is how to deploy using the `aws` command line.
 aws lambda create-function \
 --function-name MyLambda \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided  \
 --architectures arm64 \
 --role arn:aws:iam::<YOUR_ACCOUNT_ID>:role/lambda_basic_execution

--- a/Examples/S3EventNotifier/README.md
+++ b/Examples/S3EventNotifier/README.md
@@ -23,7 +23,7 @@ To build & archive the package you can use the following commands:
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there are no errors, a ZIP file should be ready to deploy, located at `.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/S3EventNotifier/S3EventNotifier.zip`.
@@ -41,7 +41,7 @@ aws lambda create-function \
     --region "${REGION}" \
     --function-name S3EventNotifier \
     --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/S3EventNotifier/S3EventNotifier.zip \
-    --runtime provided.al2 \
+    --runtime provided.al2023 \
     --handler provided  \
     --architectures arm64 \
     --role arn:aws:iam::<YOUR_ACCOUNT_ID>:role/lambda_basic_execution

--- a/Examples/S3_AWSSDK/README.md
+++ b/Examples/S3_AWSSDK/README.md
@@ -25,7 +25,7 @@ To build the package, type the following commands.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 

--- a/Examples/S3_AWSSDK/template.yaml
+++ b/Examples/S3_AWSSDK/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/AWSSDKExample/AWSSDKExample.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/S3_Soto/README.md
+++ b/Examples/S3_Soto/README.md
@@ -25,7 +25,7 @@ To build the package, type the following command.
 
 ```bash
 swift build
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 

--- a/Examples/S3_Soto/template.yaml
+++ b/Examples/S3_Soto/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/SotoExample/SotoExample.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/ServiceLifecycle+Postgres/INFRASTRUCTURE.md
+++ b/Examples/ServiceLifecycle+Postgres/INFRASTRUCTURE.md
@@ -54,7 +54,7 @@ The infrastructure consists of a secure VPC setup with private subnets only, con
 ## Lambda Function Configuration
 
 ### Service Lifecycle Lambda
-- **Runtime**: Custom runtime (provided.al2)
+- **Runtime**: Custom runtime (provided.al2023)
 - **Architecture**: ARM64
 - **Memory**: 128MB
 - **Timeout**: 60 seconds

--- a/Examples/ServiceLifecycle+Postgres/README.md
+++ b/Examples/ServiceLifecycle+Postgres/README.md
@@ -80,7 +80,7 @@ The Lambda function uses the following environment variables for database connec
 
 1. **Build the Lambda function:**
    ```bash
-   swift package archive --allow-network-connections docker
+   swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
    ```
 
 2. **Deploy with SAM:**

--- a/Examples/ServiceLifecycle+Postgres/template.yaml
+++ b/Examples/ServiceLifecycle+Postgres/template.yaml
@@ -158,7 +158,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/LambdaWithServiceLifecycle/LambdaWithServiceLifecycle.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/Streaming+APIGateway/README.md
+++ b/Examples/Streaming+APIGateway/README.md
@@ -66,7 +66,7 @@ Once the struct is created and the `handle(...)` method is defined, the sample c
 To build & archive the package, type the following commands.
 
 ```bash
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 
@@ -111,7 +111,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingNumbers/StreamingNumbers.zip
       Timeout: 60  # Must be bigger than the time it takes to stream the output
       Handler: swift.bootstrap
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/Streaming+APIGateway/template.yaml
+++ b/Examples/Streaming+APIGateway/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingNumbers/StreamingNumbers.zip
       Timeout: 60  # Must be bigger than the time it takes to stream the output
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/Streaming+Codable/README.md
+++ b/Examples/Streaming+Codable/README.md
@@ -78,7 +78,7 @@ Key features demonstrated:
 To build & archive the package, type the following commands.
 
 ```bash
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy.
@@ -119,7 +119,7 @@ AWS_ACCOUNT_ID=012345678901
 aws lambda create-function \
 --function-name StreamingFromEvent \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingFromEvent/StreamingFromEvent.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided \
 --architectures arm64 \
 --role arn:aws:iam::${AWS_ACCOUNT_ID}:role/lambda_basic_execution
@@ -231,7 +231,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingFromEvent/StreamingFromEvent.zip
       Timeout: 15
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/Streaming+Codable/template.yaml
+++ b/Examples/Streaming+Codable/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingCodable/StreamingCodable.zip
       Timeout: 15
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/Streaming+FunctionUrl/README.md
+++ b/Examples/Streaming+FunctionUrl/README.md
@@ -68,7 +68,7 @@ Once the struct is created and the `handle(...)` method is defined, the sample c
 To build & archive the package, type the following commands.
 
 ```bash
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 ```
 
 If there is no error, there is a ZIP file ready to deploy. 
@@ -100,7 +100,7 @@ AWS_ACCOUNT_ID=012345678901
 aws lambda create-function \
 --function-name StreamingNumbers \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingNumbers/StreamingNumbers.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided  \
 --architectures arm64 \
 --role arn:aws:iam::${AWS_ACCOUNT_ID}:role/lambda_basic_execution \
@@ -213,7 +213,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingNumbers/StreamingNumbers.zip
       Timeout: 15
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/Streaming+FunctionUrl/template.yaml
+++ b/Examples/Streaming+FunctionUrl/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/StreamingNumbers/StreamingNumbers.zip
       Timeout: 5  # Must be bigger than the time it takes to stream the output
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/Testing/template.yaml
+++ b/Examples/Testing/template.yaml
@@ -26,7 +26,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/APIGatewayLambda/APIGatewayLambda.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64

--- a/Examples/_MyFirstFunction/create_and_deploy_function.sh
+++ b/Examples/_MyFirstFunction/create_and_deploy_function.sh
@@ -125,7 +125,7 @@ try await runtime.run()
 EOF
 
     echo "📦 Compile and package the function for deployment (this might take a while)"
-    swift package archive --allow-network-connections docker > /dev/null 2>&1
+    swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023 > /dev/null 2>&1
 }
 
 deploy_lambda_function() {
@@ -145,7 +145,7 @@ deploy_lambda_function() {
     aws lambda create-function \
     --function-name MyLambda \
     --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip \
-    --runtime provided.al2 \
+    --runtime provided.al2023 \
     --handler provided  \
     --architectures "$(uname -m)" \
     --role arn:aws:iam::"${AWS_ACCOUNT_ID}":role/lambda_basic_execution > /dev/null 2>&1

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -509,9 +509,13 @@ private struct Configuration: CustomStringConvertible {
             baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")\(amazonLinuxVersion)"
 
         if verboseArgument {
-            print(
-                "swift version: \(swiftVersion ?? "latest"), amazon linux version: \(amazonLinuxVersion), base docker image: \(self.baseDockerImage)"
-            )
+            if baseDockerImageArgument.isEmpty {
+                print(
+                    "swift version: \(swiftVersion ?? "latest"), amazon linux version: \(amazonLinuxVersion), base docker image: \(self.baseDockerImage)"
+                )
+            } else {
+                print("base docker image (user provided): \(self.baseDockerImage)")
+            }
         }
 
         self.disableDockerImageUpdate = disableDockerImageUpdateArgument

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -509,7 +509,9 @@ private struct Configuration: CustomStringConvertible {
             baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")\(amazonLinuxVersion)"
 
         if verboseArgument {
-            print("swift version: \(swiftVersion ?? "latest"), amazon linux version: \(amazonLinuxVersion), base docker image: \(self.baseDockerImage)")
+            print(
+                "swift version: \(swiftVersion ?? "latest"), amazon linux version: \(amazonLinuxVersion), base docker image: \(self.baseDockerImage)"
+            )
         }
 
         self.disableDockerImageUpdate = disableDockerImageUpdateArgument

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -339,7 +339,8 @@ struct AWSLambdaPackager: CommandPlugin {
                                           (default is latest)
                                           This parameter cannot be used when --base-docker-image  is specified.
             --base-docker-image <name>    The name of the base docker image to use for the build.
-                                          (default : swift-<version>:amazonlinux2)
+                                          (default: swift:<version>-amazonlinux2023 for Swift >= 6.3,
+                                           swift:<version>-amazonlinux2 for earlier versions)
                                           This parameter cannot be used when --swift-version is specified.
             --disable-docker-image-update Do not attempt to update the docker image
             --container-cli <name>        The container CLI to use (docker or container)
@@ -484,8 +485,32 @@ private struct Configuration: CustomStringConvertible {
         }
 
         let swiftVersion = swiftVersionArgument.first ?? .none  // undefined version will yield the latest docker image
+
+        // Swift 6.3+ uses amazonlinux2023, earlier versions use amazonlinux2
+        let amazonLinuxVersion: String
+        if let version = swiftVersion {
+            let components = version.split(separator: ".").compactMap { Int($0) }
+            if components.count >= 2 {
+                let major = components[0]
+                let minor = components[1]
+                amazonLinuxVersion = (major > 6 || (major == 6 && minor >= 3)) ? "amazonlinux2023" : "amazonlinux2"
+            } else if let major = components.first {
+                // treat "6" (no minor) as possibly 6.0, hence amazonlinux2
+                amazonLinuxVersion = major > 6 ? "amazonlinux2023" : "amazonlinux2"
+            } else {
+                amazonLinuxVersion = "amazonlinux2023"
+            }
+        } else {
+            // no version specified means "latest", which is >= 6.3
+            amazonLinuxVersion = "amazonlinux2023"
+        }
+
         self.baseDockerImage =
-            baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")amazonlinux2"
+            baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")\(amazonLinuxVersion)"
+
+        if verboseArgument {
+            print("swift version: \(swiftVersion ?? "latest"), amazon linux version: \(amazonLinuxVersion), base docker image: \(self.baseDockerImage)")
+        }
 
         self.disableDockerImageUpdate = disableDockerImageUpdateArgument
         self.containerCLI = try ContainerCLI.parse(

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -334,7 +334,7 @@ struct AWSLambdaPackager: CommandPlugin {
         print("Amazon Linux 2023 will become the default after June 30, 2026.")
         print("")
         print("To switch now, re-run with:")
-        print("  --base-docker-image swift:6.3-amazonlinux2023")
+        print("  --base-docker-image swift:amazonlinux2023")
         print("")
         print("When using Amazon Linux 2023, you must also update your Lambda")
         print("deployment to use the provided.al2023 runtime.")

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -39,7 +39,10 @@ struct AWSLambdaPackager: CommandPlugin {
         }
 
         // display deprecation warning when building on or for Amazon Linux 2
-        if self.isAmazonLinux(.al2) || configuration.baseDockerImage.hasSuffix("amazonlinux2") {
+        if self.isAmazonLinux(.al2)
+            || (configuration.baseDockerImage.contains("amazonlinux2")
+                && !configuration.baseDockerImage.contains("amazonlinux2023"))
+        {
             self.displayDeprecationWarning()
         }
 
@@ -326,8 +329,10 @@ struct AWSLambdaPackager: CommandPlugin {
 
     private func displayDeprecationWarning() {
         let separator = String(repeating: "=", count: 68)
+        let red = "\u{001b}[38;2;255;66;69m"
+        let reset = "\u{001b}[0m"
         print("")
-        print(separator)
+        print("\(red)\(separator)")
         print("WARNING: Amazon Linux 2 reaches End of Life on June 30, 2026.")
         print("")
         print("You must migrate to Amazon Linux 2023.")
@@ -340,7 +345,8 @@ struct AWSLambdaPackager: CommandPlugin {
         print("deployment to use the provided.al2023 runtime.")
         print("")
         print("For more information: https://aws.amazon.com/amazon-linux-2")
-        print(separator)
+        print("Available images: https://hub.docker.com/_/swift/tags?name=amazonlinux")
+        print("\(separator)\(reset)")
         print("")
     }
 
@@ -376,6 +382,8 @@ struct AWSLambdaPackager: CommandPlugin {
             --base-docker-image <name>    The name of the base docker image to use for the build.
                                           (default: swift:<version>-amazonlinux2)
                                           Note: Amazon Linux 2023 will become the default after June 30, 2026.
+                                          Visit Docker Hub for all available swift tags:
+                                          https://hub.docker.com/_/swift/tags?name=amazonlinux
                                           This parameter cannot be used when --swift-version is specified.
             --disable-docker-image-update Do not attempt to update the docker image
             --container-cli <name>        The container CLI to use (docker or container)

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -38,9 +38,14 @@ struct AWSLambdaPackager: CommandPlugin {
             )
         }
 
+        // display deprecation warning when building on or for Amazon Linux 2
+        if self.isAmazonLinux(.al2) || configuration.baseDockerImage.hasSuffix("amazonlinux2") {
+            self.displayDeprecationWarning()
+        }
+
         let builtProducts: [LambdaProduct: URL]
-        if self.isAmazonLinux() {
-            // build directly on the machine
+        if self.isAmazonLinux(.al2) || self.isAmazonLinux(.al2023) {
+            // native build on Amazon Linux
             builtProducts = try self.build(
                 packageIdentity: context.package.id,
                 products: configuration.products,
@@ -299,14 +304,44 @@ struct AWSLambdaPackager: CommandPlugin {
         return archives
     }
 
-    private func isAmazonLinux() -> Bool {
-        if let data = FileManager.default.contents(atPath: "/etc/system-release"),
+    private enum AmazonLinuxVersion {
+        case al2
+        case al2023
+    }
+
+    private func isAmazonLinux(_ version: AmazonLinuxVersion) -> Bool {
+        guard let data = FileManager.default.contents(atPath: "/etc/system-release"),
             let release = String(data: data, encoding: .utf8)
-        {
-            return release.hasPrefix("Amazon Linux")
-        } else {
+        else {
             return false
         }
+        switch version {
+        case .al2023:
+            return release.hasPrefix("Amazon Linux release 2023")
+        case .al2:
+            return release.hasPrefix("Amazon Linux release 2")
+                && !release.hasPrefix("Amazon Linux release 2023")
+        }
+    }
+
+    private func displayDeprecationWarning() {
+        let separator = String(repeating: "=", count: 68)
+        print("")
+        print(separator)
+        print("WARNING: Amazon Linux 2 reaches End of Life on June 30, 2026.")
+        print("")
+        print("You must migrate to Amazon Linux 2023.")
+        print("Amazon Linux 2023 will become the default after June 30, 2026.")
+        print("")
+        print("To switch now, re-run with:")
+        print("  --base-docker-image swift:6.3-amazonlinux2023")
+        print("")
+        print("When using Amazon Linux 2023, you must also update your Lambda")
+        print("deployment to use the provided.al2023 runtime.")
+        print("")
+        print("For more information: https://aws.amazon.com/amazon-linux-2")
+        print(separator)
+        print("")
     }
 
     private func displayHelpMessage() {
@@ -339,8 +374,8 @@ struct AWSLambdaPackager: CommandPlugin {
                                           (default is latest)
                                           This parameter cannot be used when --base-docker-image  is specified.
             --base-docker-image <name>    The name of the base docker image to use for the build.
-                                          (default: swift:<version>-amazonlinux2023 for Swift >= 6.3,
-                                           swift:<version>-amazonlinux2 for earlier versions)
+                                          (default: swift:<version>-amazonlinux2)
+                                          Note: Amazon Linux 2023 will become the default after June 30, 2026.
                                           This parameter cannot be used when --swift-version is specified.
             --disable-docker-image-update Do not attempt to update the docker image
             --container-cli <name>        The container CLI to use (docker or container)
@@ -486,37 +521,8 @@ private struct Configuration: CustomStringConvertible {
 
         let swiftVersion = swiftVersionArgument.first ?? .none  // undefined version will yield the latest docker image
 
-        // Swift 6.3+ uses amazonlinux2023, earlier versions use amazonlinux2
-        let amazonLinuxVersion: String
-        if let version = swiftVersion {
-            let components = version.split(separator: ".").compactMap { Int($0) }
-            if components.count >= 2 {
-                let major = components[0]
-                let minor = components[1]
-                amazonLinuxVersion = (major > 6 || (major == 6 && minor >= 3)) ? "amazonlinux2023" : "amazonlinux2"
-            } else if let major = components.first {
-                // treat "6" (no minor) as possibly 6.0, hence amazonlinux2
-                amazonLinuxVersion = major > 6 ? "amazonlinux2023" : "amazonlinux2"
-            } else {
-                amazonLinuxVersion = "amazonlinux2023"
-            }
-        } else {
-            // no version specified means "latest", which is >= 6.3
-            amazonLinuxVersion = "amazonlinux2023"
-        }
-
         self.baseDockerImage =
-            baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")\(amazonLinuxVersion)"
-
-        if verboseArgument {
-            if baseDockerImageArgument.isEmpty {
-                print(
-                    "swift version: \(swiftVersion ?? "latest"), amazon linux version: \(amazonLinuxVersion), base docker image: \(self.baseDockerImage)"
-                )
-            } else {
-                print("base docker image (user provided): \(self.baseDockerImage)")
-            }
-        }
+            baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")amazonlinux2"
 
         self.disableDockerImageUpdate = disableDockerImageUpdateArgument
         self.containerCLI = try ContainerCLI.parse(

--- a/Plugins/Documentation.docc/Proposals/0001-v2-plugins.md
+++ b/Plugins/Documentation.docc/Proposals/0001-v2-plugins.md
@@ -185,7 +185,7 @@ OPTIONS:
                                 (default: latest)
                                 This parameter cannot be used with --base-docker-image.
 --base-docker-image <name>    The name of the base Docker image to use for the build.
-                                (default: swift-<version>:amazonlinux2)
+                                (default: swift-<version>:amazonlinux2023)
                                 This parameter cannot be used with --swift-version.
                                 This parameter cannot be used with a value other than Docker provided to --cross-compile.
 --disable-docker-image-update Do not update the Docker image before building.

--- a/Plugins/Documentation.docc/Proposals/0001-v3-plugins.md
+++ b/Plugins/Documentation.docc/Proposals/0001-v3-plugins.md
@@ -190,7 +190,7 @@ OPTIONS:
                                 (default: latest)
                                 This parameter cannot be used with --base-docker-image.
 --base-docker-image <name>    The name of the base Docker image to use for the build.
-                                (default: swift-<version>:amazonlinux2)
+                                (default: swift-<version>:amazonlinux2023)
                                 This parameter cannot be used with --swift-version.
                                 This parameter cannot be used with a value other than Docker provided to --cross-compile.
 --disable-docker-image-update Do not update the Docker image before building.

--- a/Plugins/Documentation.docc/Proposals/0001-v4-plugins.md
+++ b/Plugins/Documentation.docc/Proposals/0001-v4-plugins.md
@@ -201,7 +201,7 @@ OPTIONS:
                                 (default: latest)
                                 This parameter cannot be used with --base-docker-image.
 --base-docker-image <name>    The name of the base Docker image to use for the build.
-                                (default: swift-<version>:amazonlinux2)
+                                (default: swift-<version>:amazonlinux2023)
                                 This parameter cannot be used with --swift-version.
                                 This parameter cannot be used with a value other than Docker provided to --cross-compile.
 --disable-docker-image-update Do not update the Docker image before building.

--- a/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
@@ -70,7 +70,9 @@ Here is the content of this guide:
    Compile and package the function using the following command
 
    ```sh
-   swift package archive --allow-network-connections docker
+   swift package archive \
+         --allow-network-connections docker \
+         --base-docker-image swift:6.3-amazonlinux2023
    ```
 
    This command creates a ZIP file with the compiled Swift code. The ZIP file is located in the `.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip` folder.
@@ -113,7 +115,7 @@ Select **Create a function** to create a function.
 
 ![Console - Lambda dashboard when there is no function](console-20-dashboard)
 
-Select **Author function from scratch**. Enter a **Function name** (`HelloWorld`) and select `Amazon Linux 2` as **Runtime**.
+Select **Author function from scratch**. Enter a **Function name** (`HelloWorld`) and select `Amazon Linux 2023` as **Runtime**.
 Select the architecture. When you compile your Swift code on a x84_64 machine, such as an Intel Mac, select `x86_64`. When you compile your Swift code on an Arm machine, such as the Apple Silicon M1 or more recent, select `arm64`.
 
 Select **Create function**
@@ -124,7 +126,7 @@ On the right side, select **Upload from** and select **.zip file**.
 
 ![Console - select zip file](console-40-select-zip-file)
 
-Select the zip file created with the `swift package archive --allow-network-connections docker` command as described in the [Prerequisites](#prerequisites) section.
+Select the zip file created with the `swift package archive` command as described in the [Prerequisites](#prerequisites) section.
 
 Select **Save**
 
@@ -188,7 +190,7 @@ In this example, we're building the HelloWorld example from the [Examples](https
 
 To create a function, you must first create the function execution role and define the permission. Then, you create the function with the `create-function` command.
 
-The command assumes you've already created the ZIP file with the `swift package archive --allow-network-connections docker` command, as described in the [Prerequisites](#prerequisites) section.
+The command assumes you've already created the ZIP file with the `swift package archive` command, as described in the [Prerequisites](#prerequisites) section.
  
 ```sh
 # enter your AWS Account ID 
@@ -243,7 +245,7 @@ aws iam put-role-policy \
 aws lambda create-function \
 --function-name MyLambda \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided  \
 --architectures arm64 \
 --role arn:aws:iam::${AWS_ACCOUNT_ID}:role/lambda_basic_execution
@@ -510,7 +512,7 @@ export class LambdaApiStack extends cdk.Stack {
  }
 }    
 ```
-The code assumes you already built and packaged the APIGateway Lambda function with the `swift package archive --allow-network-connections docker` command, as described in the [Prerequisites](#prerequisites) section.
+The code assumes you already built and packaged the APIGateway Lambda function with the `swift package archive` command, as described in the [Prerequisites](#prerequisites) section.
 
 You can write code to add an API Gateway to invoke your Lambda function. The following code creates an HTTP API Gateway that triggers the Lambda function.
 

--- a/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
@@ -72,7 +72,7 @@ Here is the content of this guide:
    ```sh
    swift package archive \
          --allow-network-connections docker \
-         --base-docker-image swift:6.3-amazonlinux2023
+         --base-docker-image swift:amazonlinux2023
    ```
 
    This command creates a ZIP file with the compiled Swift code. The ZIP file is located in the `.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip` folder.

--- a/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-02-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-02-plugin-archive.sh
@@ -1,1 +1,1 @@
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023

--- a/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-02-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-02-plugin-archive.sh
@@ -1,1 +1,1 @@
-swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023

--- a/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-03-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-03-plugin-archive.sh
@@ -1,4 +1,4 @@
-swift package archive --allow-network-connections docker 
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 
 -------------------------------------------------------------------------
 building "palindrome" in docker
@@ -6,8 +6,8 @@ building "palindrome" in docker
 updating "swift:amazonlinux2" docker image
   amazonlinux2: Pulling from library/swift
   Digest: sha256:df06a50f70e2e87f237bd904d2fc48195742ebda9f40b4a821c4d39766434009
-Status: Image is up to date for swift:amazonlinux2
-  docker.io/library/swift:amazonlinux2
+Status: Image is up to date for swift:amazonlinux2023
+  docker.io/library/swift:amazonlinux2023
 building "PalindromeLambda"
   [0/1] Planning build
   Building for production...

--- a/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-03-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-03-plugin-archive.sh
@@ -3,8 +3,8 @@ swift package archive --allow-network-connections docker --base-docker-image swi
 -------------------------------------------------------------------------
 building "palindrome" in docker
 -------------------------------------------------------------------------
-updating "swift:amazonlinux2" docker image
-  amazonlinux2: Pulling from library/swift
+updating "swift:amazonlinux2023" docker image
+  amazonlinux2023: Pulling from library/swift
   Digest: sha256:df06a50f70e2e87f237bd904d2fc48195742ebda9f40b4a821c4d39766434009
 Status: Image is up to date for swift:amazonlinux2023
   docker.io/library/swift:amazonlinux2023

--- a/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-04-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-04-plugin-archive.sh
@@ -1,4 +1,4 @@
-swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 
 -------------------------------------------------------------------------
 building "palindrome" in docker

--- a/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-04-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-04-plugin-archive.sh
@@ -1,4 +1,4 @@
-swift package archive --allow-network-connections docker
+swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023
 
 -------------------------------------------------------------------------
 building "palindrome" in docker
@@ -6,8 +6,8 @@ building "palindrome" in docker
 updating "swift:amazonlinux2" docker image
   amazonlinux2: Pulling from library/swift
   Digest: sha256:df06a50f70e2e87f237bd904d2fc48195742ebda9f40b4a821c4d39766434009
-Status: Image is up to date for swift:amazonlinux2
-  docker.io/library/swift:amazonlinux2
+Status: Image is up to date for swift:amazonlinux2023
+  docker.io/library/swift:amazonlinux2023
 building "PalindromeLambda"
   [0/1] Planning build
   Building for production...

--- a/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-04-plugin-archive.sh
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Resources/code/04-01-04-plugin-archive.sh
@@ -3,8 +3,8 @@ swift package archive --allow-network-connections docker --base-docker-image swi
 -------------------------------------------------------------------------
 building "palindrome" in docker
 -------------------------------------------------------------------------
-updating "swift:amazonlinux2" docker image
-  amazonlinux2: Pulling from library/swift
+updating "swift:amazonlinux2023" docker image
+  amazonlinux2023: Pulling from library/swift
   Digest: sha256:df06a50f70e2e87f237bd904d2fc48195742ebda9f40b4a821c4d39766434009
 Status: Image is up to date for swift:amazonlinux2023
   docker.io/library/swift:amazonlinux2023

--- a/Sources/AWSLambdaRuntime/Docs.docc/quick-setup.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/quick-setup.md
@@ -118,8 +118,8 @@ swift package archive --allow-network-connections docker --base-docker-image swi
 -------------------------------------------------------------------------
 building "MyFirstLambdaFunction" in docker
 -------------------------------------------------------------------------
-updating "swift:amazonlinux2" docker image
-  amazonlinux2: Pulling from library/swift
+updating "swift:amazonlinux2023" docker image
+  amazonlinux2023: Pulling from library/swift
   Digest: sha256:5b0cbe56e35210fa90365ba3a4db9cd2b284a5b74d959fc1ee56a13e9c35b378
   Status: Image is up to date for swift:amazonlinux2023
   docker.io/library/swift:amazonlinux2023

--- a/Sources/AWSLambdaRuntime/Docs.docc/quick-setup.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/quick-setup.md
@@ -113,7 +113,7 @@ AWS Lambda runtime runs on Amazon Linux. You must compile your code for Amazon L
 > Be sure to have [Docker](https://docs.docker.com/desktop/install/mac-install/) installed for this step.
 
 ```sh
-swift package --allow-network-connections docker archive
+swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023
 
 -------------------------------------------------------------------------
 building "MyFirstLambdaFunction" in docker
@@ -121,8 +121,8 @@ building "MyFirstLambdaFunction" in docker
 updating "swift:amazonlinux2" docker image
   amazonlinux2: Pulling from library/swift
   Digest: sha256:5b0cbe56e35210fa90365ba3a4db9cd2b284a5b74d959fc1ee56a13e9c35b378
-  Status: Image is up to date for swift:amazonlinux2
-  docker.io/library/swift:amazonlinux2
+  Status: Image is up to date for swift:amazonlinux2023
+  docker.io/library/swift:amazonlinux2023
 building "MyFirstLambdaFunction"
   Building for production...
 ...
@@ -135,6 +135,8 @@ archiving "MyFirstLambdaFunction"
 
 cp .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyFirstLambdaFunction/MyFirstLambdaFunction.zip ~/Desktop
 ```
+
+> Note: The archive command currently defaults to Amazon Linux 2 (`swift:amazonlinux2`) as the build environment. Amazon Linux 2 reaches End of Life on June 30, 2026 and the default will change to Amazon Linux 2023 after that date. To migrate early, re-run the archive command with `--base-docker-image swift:6.3-amazonlinux2023`. When deploying a function built on Amazon Linux 2023, you must use the `provided.al2023` Lambda runtime instead of `provided.al2`.
 
 6. Deploy on AWS Lambda
 

--- a/Sources/AWSLambdaRuntime/Docs.docc/quick-setup.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/quick-setup.md
@@ -113,7 +113,7 @@ AWS Lambda runtime runs on Amazon Linux. You must compile your code for Amazon L
 > Be sure to have [Docker](https://docs.docker.com/desktop/install/mac-install/) installed for this step.
 
 ```sh
-swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023
 
 -------------------------------------------------------------------------
 building "MyFirstLambdaFunction" in docker
@@ -136,7 +136,7 @@ archiving "MyFirstLambdaFunction"
 cp .build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyFirstLambdaFunction/MyFirstLambdaFunction.zip ~/Desktop
 ```
 
-> Note: The archive command currently defaults to Amazon Linux 2 (`swift:amazonlinux2`) as the build environment. Amazon Linux 2 reaches End of Life on June 30, 2026 and the default will change to Amazon Linux 2023 after that date. To migrate early, re-run the archive command with `--base-docker-image swift:6.3-amazonlinux2023`. When deploying a function built on Amazon Linux 2023, you must use the `provided.al2023` Lambda runtime instead of `provided.al2`.
+> Note: The archive command currently defaults to Amazon Linux 2 (`swift:amazonlinux2`) as the build environment. Amazon Linux 2 reaches End of Life on June 30, 2026 and the default will change to Amazon Linux 2023 after that date. To migrate early, re-run the archive command with `--base-docker-image swift:amazonlinux2023`. When deploying a function built on Amazon Linux 2023, you must use the `provided.al2023` Lambda runtime instead of `provided.al2`.
 
 6. Deploy on AWS Lambda
 

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ The runtime comes with a plugin to compile on Amazon Linux and create a ZIP arch
 ```bash
 swift package archive \
       --allow-network-connections docker \
-      --base-docker-image swift:6.3-amazonlinux2023
+      --base-docker-image swift:amazonlinux2023
 ```
 
 By default, it runs on `docker` but it also allows you to build with [Apple container](https://github.com/apple/container) (it requires disabling the sandbox):
@@ -150,7 +150,7 @@ By default, it runs on `docker` but it also allows you to build with [Apple cont
 # until https://github.com/swiftlang/swift-package-manager/issues/9763 is fixed
 swift package --disable-sandbox \
               --allow-network-connections docker \
-              --base-docker-image swift:6.3-amazonlinux2023 \
+              --base-docker-image swift:amazonlinux2023 \
               archive \
               --container-cli container
 ```
@@ -162,11 +162,11 @@ The ZIP file is located at `.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPa
    > If you encounter Docker credential store errors during the build, remove the `credsStore` entry from your `~/.docker/config.json` file or disable the plugin sandbox with `--disable-sandbox`. See [issue #609](https://github.com/awslabs/swift-aws-lambda-runtime/issues/609) for details.
 
 > [!NOTE]
-> The archive plugin currently defaults to Amazon Linux 2 as the build environment. After June 30, 2026, the default will change to Amazon Linux 2023. To migrate early, add the `--base-docker-image swift:6.3-amazonlinux2023` flag to the archive command:
+> The archive plugin currently defaults to Amazon Linux 2 as the build environment. After June 30, 2026, the default will change to Amazon Linux 2023. To migrate early, add the `--base-docker-image swift:amazonlinux2023` flag to the archive command:
 > ```bash
 > swift package archive \
 >       --allow-network-connections docker \
->       --base-docker-image swift:6.3-amazonlinux2023
+>       --base-docker-image swift:amazonlinux2023
 > ```
 > When deploying functions built on Amazon Linux 2023, you must use the `provided.al2023` runtime instead of `provided.al2` in the `aws lambda create-function` command.
 

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,9 @@ try await runtime.run()
 The runtime comes with a plugin to compile on Amazon Linux and create a ZIP archive:
 
 ```bash
-swift package archive --allow-network-connections docker
+swift package archive \
+      --allow-network-connections docker \
+      --base-docker-image swift:6.3-amazonlinux2023
 ```
 
 By default, it runs on `docker` but it also allows you to build with [Apple container](https://github.com/apple/container) (it requires disabling the sandbox):
@@ -148,6 +150,7 @@ By default, it runs on `docker` but it also allows you to build with [Apple cont
 # until https://github.com/swiftlang/swift-package-manager/issues/9763 is fixed
 swift package --disable-sandbox \
               --allow-network-connections docker \
+              --base-docker-image swift:6.3-amazonlinux2023 \
               archive \
               --container-cli container
 ```
@@ -157,6 +160,15 @@ The ZIP file is located at `.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPa
 
  >[!NOTE]
    > If you encounter Docker credential store errors during the build, remove the `credsStore` entry from your `~/.docker/config.json` file or disable the plugin sandbox with `--disable-sandbox`. See [issue #609](https://github.com/awslabs/swift-aws-lambda-runtime/issues/609) for details.
+
+> [!NOTE]
+> The archive plugin currently defaults to Amazon Linux 2 as the build environment. After June 30, 2026, the default will change to Amazon Linux 2023. To migrate early, add the `--base-docker-image swift:6.3-amazonlinux2023` flag to the archive command:
+> ```bash
+> swift package archive \
+>       --allow-network-connections docker \
+>       --base-docker-image swift:6.3-amazonlinux2023
+> ```
+> When deploying functions built on Amazon Linux 2023, you must use the `provided.al2023` runtime instead of `provided.al2` in the `aws lambda create-function` command.
 
 5. Deploy to AWS
 
@@ -168,7 +180,7 @@ Here is how to deploy using the `aws` command line.
 aws lambda create-function \
 --function-name MyLambda \
 --zip-file fileb://.build/plugins/AWSLambdaPackager/outputs/AWSLambdaPackager/MyLambda/MyLambda.zip \
---runtime provided.al2 \
+--runtime provided.al2023 \
 --handler provided  \
 --architectures arm64 \
 --role arn:aws:iam::<YOUR_ACCOUNT_ID>:role/lambda_basic_execution

--- a/scripts/ubuntu-test-plugin.sh
+++ b/scripts/ubuntu-test-plugin.sh
@@ -26,4 +26,4 @@ git clone https://github.com/awslabs/swift-aws-lambda-runtime.git
 
 # build the project
 cd swift-aws-lambda-runtime/Examples/ResourcesPackaging/ || exit 1
-swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023
+swift package archive --allow-network-connections docker --base-docker-image swift:amazonlinux2023

--- a/scripts/ubuntu-test-plugin.sh
+++ b/scripts/ubuntu-test-plugin.sh
@@ -26,4 +26,4 @@ git clone https://github.com/awslabs/swift-aws-lambda-runtime.git
 
 # build the project
 cd swift-aws-lambda-runtime/Examples/ResourcesPackaging/ || exit 1
-swift package archive --allow-network-connections docker                                      
+swift package archive --allow-network-connections docker --base-docker-image swift:6.3-amazonlinux2023


### PR DESCRIPTION

This PR has been reworked. Instead of silently switching the default base image based on Swift version, we now:

1. **Keep Amazon Linux 2 as the default** base Docker image for the packager plugin
2. **Add a prominent deprecation warning** when AL2 is used (either via Docker or natively), informing developers that AL2 reaches End of Life on June 30, 2026
3. **Migrate all examples** (READMEs, SAM templates, scripts) to build and deploy on Amazon Linux 2023 (`provided.al2023` runtime + `--base-docker-image swift:amazonlinux2023`)
4. **Update documentation** (readme, quick-setup) with migration notes

The warning includes the `--base-docker-image swift:6.3-amazonlinux2023` flag and reminds developers to use the `provided.al2023` runtime when deploying.

After June 30, 2026, the default will switch to AL2023.

---

<details>
<summary>Original PR description (superseded)</summary>

~~Now that Docker Hub has official Swift images based on Amazon Linux 2023 (starting with 6.3), the packager plugin picks the right base image automatically depending on the Swift version:~~
~~- Swift 6.3 and later: `swift:<version>-amazonlinux2023`~~
~~- Earlier versions: `swift:<version>-amazonlinux2` (unchanged behavior)~~
~~- No version specified (latest): defaults to `amazonlinux2023`~~

~~When only a major version is provided (e.g. `--swift-version 6` without a minor), we conservatively treat it as 6.0 and use Amazon Linux 2, since we can't be sure it's 6.3+.~~
~~Also added a verbose log line showing the resolved Swift version, Amazon Linux version, and final base image to help with debugging.~~
~~The `--base-docker-image` flag still overrides everything as before.~~

</details>