### PR TITLE
[plugin] AmazonLinux2023 is now the default

### DIFF
--- a/Examples/CDK/infra/lib/lambda-api-project-stack.ts
+++ b/Examples/CDK/infra/lib/lambda-api-project-stack.ts
@@ -24,7 +24,7 @@ export class LambdaApiStack extends cdk.Stack {
 
     // Create the Lambda function
     const lambdaFunction = new lambda.Function(this, 'SwiftLambdaFunction', {
-      runtime: lambda.Runtime.PROVIDED_AL2,
+      runtime: lambda.Runtime.PROVIDED_AL2023,
       architecture: lambda.Architecture.ARM_64,
       handler: 'bootstrap',
       code: lambda.Code.fromAsset('../.build/plugins/AWSLambdaBuilder/outputs/AWSLambdaBuilder/APIGatewayLambda/APIGatewayLambda.zip'),

--- a/Plugins/AWSLambdaBuilder/Plugin.swift
+++ b/Plugins/AWSLambdaBuilder/Plugin.swift
@@ -77,9 +77,6 @@ struct AWSLambdaBuilder: CommandPlugin {
             buildConfiguration = .release
         }
 
-        // TODO: When running on Amazon Linux 2, we have to build directly from the plugin
-        // launch the build, then call the helper just for the ZIP part
-
         let tool = try context.tool(named: "AWSLambdaPluginHelper")
         let args =
             [
@@ -109,47 +106,6 @@ struct AWSLambdaBuilder: CommandPlugin {
             Diagnostics.error("AWSLambdaPluginHelper invocation failed: \(problem)")
         }
     }
-
-    // TODO: When running on Amazon Linux 2, we have to build directly from the plugin
-    //    private func build(
-    //        packageIdentity: Package.ID,
-    //        products: [Product],
-    //        buildConfiguration: PackageManager.BuildConfiguration,
-    //        verboseLogging: Bool
-    //    ) throws -> [LambdaProduct: URL] {
-    //        print("-------------------------------------------------------------------------")
-    //        print("building \"\(packageIdentity)\"")
-    //        print("-------------------------------------------------------------------------")
-    //
-    //        var results = [LambdaProduct: URL]()
-    //        for product in products {
-    //            print("building \"\(product.name)\"")
-    //            var parameters = PackageManager.BuildParameters()
-    //            parameters.configuration = buildConfiguration
-    //            parameters.otherSwiftcFlags = ["-static-stdlib"]
-    //            parameters.logging = verboseLogging ? .verbose : .concise
-    //
-    //            let result = try packageManager.build(
-    //                .product(product.name),
-    //                parameters: parameters
-    //            )
-    //            guard let artifact = result.executableArtifact(for: product) else {
-    //                throw Errors.productExecutableNotFound(product.name)
-    //            }
-    //            results[.init(product)] = artifact.url
-    //        }
-    //        return results
-    //    }
-
-    //    private func isAmazonLinux2() -> Bool {
-    //         if let data = FileManager.default.contents(atPath: "/etc/system-release"),
-    //             let release = String(data: data, encoding: .utf8)
-    //         {
-    //             return release.hasPrefix("Amazon Linux release 2")
-    //         } else {
-    //             return false
-    //         }
-    //     }
 }
 
 private enum BuilderErrors: Error, CustomStringConvertible {

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -388,8 +388,8 @@ struct AWSLambdaPackager: CommandPlugin {
                                           (default is latest)
                                           This parameter cannot be used when --base-docker-image  is specified.
             --base-docker-image <name>    The name of the base docker image to use for the build.
-                                          (default: swift:<version>-amazonlinux2)
-                                          Note: Amazon Linux 2023 will become the default after June 30, 2026.
+                                          (default: swift:<version>-amazonlinux2023)
+                                          Amazon Linux 2 is deprecated since June 30, 2026.
                                           Visit Docker Hub for all available swift tags:
                                           https://hub.docker.com/_/swift/tags?name=amazonlinux
                                           This parameter cannot be used when --swift-version is specified.
@@ -538,7 +538,7 @@ private struct Configuration: CustomStringConvertible {
         let swiftVersion = swiftVersionArgument.first ?? .none  // undefined version will yield the latest docker image
 
         self.baseDockerImage =
-            baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")amazonlinux2"
+            baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")amazonlinux2023"  // default to Amazon Linux 2023 since 30 June 2026
 
         self.disableDockerImageUpdate = disableDockerImageUpdateArgument
         self.containerCLI = try ContainerCLI.parse(

--- a/Plugins/AWSLambdaPackager/Plugin.swift
+++ b/Plugins/AWSLambdaPackager/Plugin.swift
@@ -537,8 +537,9 @@ private struct Configuration: CustomStringConvertible {
 
         let swiftVersion = swiftVersionArgument.first ?? .none  // undefined version will yield the latest docker image
 
+        // default to Amazon Linux 2023 after 30 June 2026 (Amazon Linux 2 is deprecated)
         self.baseDockerImage =
-            baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")amazonlinux2023"  // default to Amazon Linux 2023 since 30 June 2026
+            baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")amazonlinux2023"
 
         self.disableDockerImageUpdate = disableDockerImageUpdateArgument
         self.containerCLI = try ContainerCLI.parse(

--- a/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
@@ -382,6 +382,7 @@ struct Builder {
                                           This parameter cannot be used when --base-docker-image is specified.
             --base-docker-image <name>    The name of the base docker image to use for the build.
                                           (default: swift:<version>-amazonlinux2023)
+                                          Amazon Linux 2 is deprecated since June 30, 2026.
                                           Visit Docker Hub for all available swift tags:
                                           https://hub.docker.com/_/swift/tags?name=amazonlinux
                                           This parameter cannot be used when --swift-version is specified.

--- a/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/Deployment.md
@@ -292,7 +292,7 @@ Resources:
       CodeUri: .build/plugins/AWSLambdaBuilder/outputs/AWSLambdaBuilder/APIGatewayLambda/APIGatewayLambda.zip
       Timeout: 60
       Handler: swift.bootstrap  # ignored by the Swift runtime
-      Runtime: provided.al2
+      Runtime: provided.al2023
       MemorySize: 128
       Architectures:
         - arm64
@@ -466,7 +466,7 @@ export class LambdaApiStack extends cdk.Stack {
 
     // Create the Lambda function
     const lambdaFunction = new lambda.Function(this, 'SwiftLambdaFunction', {
-      runtime: lambda.Runtime.PROVIDED_AL2,
+      runtime: lambda.Runtime.PROVIDED_AL2023,
       architecture: lambda.Architecture.ARM_64,
       handler: 'bootstrap',
       code: lambda.Code.fromAsset('../.build/plugins/AWSLambdaBuilder/outputs/AWSLambdaBuilder/APIGatewayLambda/APIGatewayLambda.zip'),


### PR DESCRIPTION
Starting June, 20 2026, Amazon Linux 2 has reached end of support life.
The Swift Lambda Runtime plugins now use Amazon Linux 2023 for cross compiling code.

> [!WARNING]  
> When you compile on Amazon Linux 2023, you must deploy on Amazon Linux 2023 too

**When using the console**
<img width="946" height="254" alt="image" src="https://github.com/user-attachments/assets/6289a194-348c-4d90-be24-df7cdfb7e8c3" />

**When using the AWS CLI** 
```sh
aws lambda create-function \
    --function-name MySwiftFunction \
    --runtime provided.al2023 \
    --role "$role_arn" \ // replace with the IAM role ARN to pass to your function
    --handler bootstrap \
    --architectures arm64 \
    --zip-file "fileb://MySwiftFunction.zip"
```

**When using SAM** 
```yaml
Resources:
  APIGatewayLambda:
    Type: AWS::Serverless::Function
    Properties:
      CodeUri: APIGatewayLambda.zip
      Timeout: 60
      Handler: swift.bootstrap  # ignored by the Swift runtime
      Runtime: provided.al2023
      MemorySize: 128
      Architectures:
        - arm64
```

**When using the AWS CDK** 

```ts
  const lambdaFunction = new lambda.Function(this, 'SwiftLambdaFunction', {
    runtime: lambda.Runtime.PROVIDED_AL2023,
    architecture: lambda.Architecture.ARM_64,
    handler: 'bootstrap',
    code: lambda.Code.fromAsset('APIGatewayLambda.zip'),
    memorySize: 128,
    timeout: cdk.Duration.seconds(30),
    environment: {
      LOG_LEVEL: 'debug',
    },
  });
```

