### PR TITLE
[plugin] Fix: resolve the container CLI matching the cross-compile method (lambda-build & archive)

### DIFF
--- a/Plugins/AWSLambdaBuilder/Plugin.swift
+++ b/Plugins/AWSLambdaBuilder/Plugin.swift
@@ -28,7 +28,6 @@ struct AWSLambdaBuilder: CommandPlugin {
         let packageID: String = context.package.id
         let packageDisplayName = context.package.displayName
         let packageDirectory = context.package.directoryURL
-        let dockerToolPath = try context.tool(named: "docker").url
         let zipToolPath = try context.tool(named: "zip").url
 
         // extract arguments that require PluginContext to fully resolve
@@ -38,6 +37,18 @@ struct AWSLambdaBuilder: CommandPlugin {
         let outputPathArgument = argumentExtractor.extractOption(named: "output-path")
         let productsArgument = argumentExtractor.extractOption(named: "products")
         let configurationArgument = argumentExtractor.extractOption(named: "configuration")
+
+        // Resolve the container CLI that matches the requested cross-compilation method.
+        // The plugin sandbox can only run tools it resolves up front, so we must pick the right
+        // binary here — `container` for `--cross-compile container`, `docker` otherwise. Extracting
+        // these options only peeks them for the plugin; the original `arguments` (which the helper
+        // re-parses) is still forwarded unchanged below.
+        // `--container-cli` is a deprecated alias for `--cross-compile`.
+        let crossCompileArgument = argumentExtractor.extractOption(named: "cross-compile")
+        let containerCliArgument = argumentExtractor.extractOption(named: "container-cli")
+        let crossCompileMethod = (crossCompileArgument.first ?? containerCliArgument.first)?.lowercased()
+        let containerCLIToolName = crossCompileMethod == "container" ? "container" : "docker"
+        let containerToolPath = try context.tool(named: containerCLIToolName).url
 
         if let outputPath = outputPathArgument.first {
             #if os(Linux)
@@ -87,7 +98,7 @@ struct AWSLambdaBuilder: CommandPlugin {
                 "--package-id", packageID,
                 "--package-display-name", packageDisplayName,
                 "--package-directory", packageDirectory.path(),
-                "--docker-tool-path", dockerToolPath.path,
+                "--docker-tool-path", containerToolPath.path,
                 "--zip-tool-path", zipToolPath.path,
             ] + arguments
 

--- a/Plugins/AWSLambdaPackager/Plugin@swift-6.4.swift
+++ b/Plugins/AWSLambdaPackager/Plugin@swift-6.4.swift
@@ -39,7 +39,6 @@ struct AWSLambdaPackager: CommandPlugin {
         let packageID: String = context.package.id
         let packageDisplayName = context.package.displayName
         let packageDirectory = context.package.directoryURL
-        let dockerToolPath = try context.tool(named: "docker").url
         let zipToolPath = try context.tool(named: "zip").url
 
         var argumentExtractor = ArgumentExtractor(arguments)
@@ -48,6 +47,17 @@ struct AWSLambdaPackager: CommandPlugin {
         let outputDirectoryArgument = argumentExtractor.extractOption(named: "output-directory")
         let productsArgument = argumentExtractor.extractOption(named: "products")
         let configurationArgument = argumentExtractor.extractOption(named: "configuration")
+
+        // Resolve the container CLI that matches the requested cross-compilation method.
+        // The plugin sandbox can only run tools it resolves up front, so we must pick the right
+        // binary here — `container` for `container`, `docker` otherwise. Extracting these options
+        // only peeks them for the plugin; the original `arguments` (which the helper re-parses) is
+        // still forwarded unchanged below. `--container-cli` is the legacy alias for `--cross-compile`.
+        let crossCompileArgument = argumentExtractor.extractOption(named: "cross-compile")
+        let containerCliArgument = argumentExtractor.extractOption(named: "container-cli")
+        let crossCompileMethod = (crossCompileArgument.first ?? containerCliArgument.first)?.lowercased()
+        let containerCLIToolName = crossCompileMethod == "container" ? "container" : "docker"
+        let containerToolPath = try context.tool(named: containerCLIToolName).url
 
         // output directory
         if let outputPath = outputPathArgument.first ?? outputDirectoryArgument.first {
@@ -100,7 +110,7 @@ struct AWSLambdaPackager: CommandPlugin {
                 "--package-id", packageID,
                 "--package-display-name", packageDisplayName,
                 "--package-directory", packageDirectory.path(),
-                "--docker-tool-path", dockerToolPath.path,
+                "--docker-tool-path", containerToolPath.path,
                 "--zip-tool-path", zipToolPath.path,
             ] + arguments
 

--- a/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
@@ -464,7 +464,7 @@ enum CrossCompileMethod: String, CustomStringConvertible {
             return args
         }
         switch self {
-        
+
         case .docker:
             return genericArgs()
 
@@ -478,7 +478,7 @@ enum CrossCompileMethod: String, CustomStringConvertible {
             }
 
             return args
-            
+
         case .swiftStaticSdk, .customSdk:
             fatalError("runArguments should not be called for unsupported cross-compile methods")
         }

--- a/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
@@ -450,19 +450,35 @@ enum CrossCompileMethod: String, CustomStringConvertible {
         env: [String: String]?,
         command: String
     ) -> [String] {
-        switch self {
-        case .docker, .container:
+        func genericArgs() -> [String] {
             var args: [String] = ["run", "--rm"]
             for mount in mounts {
                 args += ["-v", mount]
             }
             if let env {
                 for (key, value) in env.sorted(by: { $0.key < $1.key }) {
-                    args += ["--env", "\(key)=\(value)"]
+                    args += ["-e", "\(key)=\(value)"]
                 }
             }
             args += ["-w", workingDirectory, baseImage, "bash", "-cl", command]
             return args
+        }
+        switch self {
+        
+        case .docker:
+            return genericArgs()
+
+        case .container:
+            var args = genericArgs()
+
+            // container's runtime needs a bit more memory
+            if self == .container {
+                args.insert("--memory", at: 1)
+                args.insert("4G", at: 2)
+            }
+
+            return args
+            
         case .swiftStaticSdk, .customSdk:
             fatalError("runArguments should not be called for unsupported cross-compile methods")
         }


### PR DESCRIPTION
### Problem

Cross-compiling with Apple's `container` CLI did not work — neither via the new `lambda-build` plugin nor the legacy `archive` plugin. The build failed with:

```
/usr/local/bin/docker image pull swift:amazonlinux2023
  failed to connect to the docker API at unix:///Users/.../docker.sock ...
```

Both plugins **always** resolved the Docker binary (`context.tool(named: "docker")`) and forwarded it as the container CLI path, regardless of the selected cross-compilation method. So when `container` was requested, the plugin generated correct `container`-style arguments (`image pull …`) but executed them with the **docker** binary, which then failed.

Tool resolution has to happen in the plugin (the SwiftPM sandbox can only run tools it resolves up front), so the fix belongs there rather than in the helper.

### Fix

Both plugins now peek the cross-compilation flag and resolve the matching tool — `container` when `container` is requested, `docker` otherwise — before invoking the helper. The original arguments are still forwarded unchanged.

- **`AWSLambdaBuilder`** (`lambda-build`): honours `--cross-compile` (and the deprecated `--container-cli` alias).
- **`AWSLambdaPackager`** (`archive`, Swift 6.4 deprecation passthrough): same bug, same fix; honours both `--cross-compile` and the legacy `--container-cli`.

### Testing

Verified end-to-end against a sample project for both commands:

- **Default (no flag):** resolves `/usr/local/bin/docker` — unchanged behaviour.
- **`--cross-compile container` / `--container-cli container`:** resolves `/usr/local/bin/container`; the plugin now runs `/usr/local/bin/container image pull …` and the Linux container starts and builds.

> [!NOTE]
> There is a separate, pre-existing limitation: Apple's `container` CLI communicates with its daemon over XPC, which the SwiftPM plugin sandbox blocks (`XPC connection error: Connection invalid`). The same command succeeds with `--disable-sandbox`. That sandbox issue is out of scope for this PR (which fixes the tool-resolution bug) and should be tracked separately.
