### PR TITLE
[plugin] Move cross-compile backend factory to BuilderConfiguration; fix log handler deprecation warning

### DIFF
--- a/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
@@ -36,11 +36,11 @@ struct Builder {
 
         // Select the build backend: build natively when already on an Amazon Linux host,
         // otherwise cross-compile using the backend chosen by --cross-compile.
-        let backend: BuildBackend
+        let backend: any BuildBackend
         if self.isAmazonLinux(.al2) || self.isAmazonLinux(.al2023) {
             backend = NativeBuildBackend()
         } else {
-            backend = try configuration.crossCompileMethod.makeBackend(configuration: configuration)
+            backend = try configuration.makeCrossCompileBackend()
         }
 
         let builtProducts = try backend.build(
@@ -377,6 +377,30 @@ struct BuilderConfiguration: CustomStringConvertible {
             print("-------------------------------------------------------------------------")
             print(self)
         }
+    }
+
+    /// Creates the ``BuildBackend`` that performs a cross-compiled build for the configured method.
+    ///
+    /// Used when the host is not already an Amazon Linux machine. The configuration already holds
+    /// everything a backend needs (the resolved tool path, base image, and image-update
+    /// preference), so the factory lives here rather than on ``CrossCompileMethod``.
+    func makeCrossCompileBackend() throws -> any BuildBackend {
+        let cli: any ContainerCLI
+        switch self.crossCompileMethod {
+        case .docker:
+            cli = DockerCLI()
+        case .container:
+            cli = AppleContainerCLI()
+        case .swiftStaticSdk, .customSdk:
+            throw BuilderErrors.unsupportedCrossCompileMethod(self.crossCompileMethod)
+        }
+        return ContainerBuildBackend(
+            cli: cli,
+            toolPath: self.crossCompileToolPath,
+            baseImage: self.baseDockerImage,
+            disableImageUpdate: self.disableDockerImageUpdate,
+            method: self.crossCompileMethod
+        )
     }
 
     var description: String {

--- a/Sources/AWSLambdaPluginHelper/lambda-build/CrossCompileMethod.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/CrossCompileMethod.swift
@@ -21,9 +21,10 @@ import Foundation
 
 /// The cross-compilation method requested via `--cross-compile`.
 ///
-/// This enum is the parsed user choice and a factory for the matching ``BuildBackend``. It holds
-/// no execution logic itself: container argument spelling lives in the ``ContainerCLI`` types and
-/// the build flow lives in the ``BuildBackend`` types.
+/// This enum is purely the parsed user choice. It holds no execution logic: container argument
+/// spelling lives in the ``ContainerCLI`` types, the build flow lives in the ``BuildBackend``
+/// types, and backend construction lives on ``BuilderConfiguration`` (which holds everything a
+/// backend needs).
 @available(LambdaSwift 2.0, *)
 enum CrossCompileMethod: String, CustomStringConvertible {
     case docker
@@ -54,29 +55,6 @@ enum CrossCompileMethod: String, CustomStringConvertible {
         }
 
         return method
-    }
-
-    /// Creates the ``BuildBackend`` that performs a cross-compiled build for this method.
-    ///
-    /// Used when the host is not already an Amazon Linux machine. The configuration supplies the
-    /// resolved tool path, base image, and image-update preference.
-    func makeBackend(configuration: BuilderConfiguration) throws -> BuildBackend {
-        let cli: ContainerCLI
-        switch self {
-        case .docker:
-            cli = DockerCLI()
-        case .container:
-            cli = AppleContainerCLI()
-        case .swiftStaticSdk, .customSdk:
-            throw BuilderErrors.unsupportedCrossCompileMethod(self)
-        }
-        return ContainerBuildBackend(
-            cli: cli,
-            toolPath: configuration.crossCompileToolPath,
-            baseImage: configuration.baseDockerImage,
-            disableImageUpdate: configuration.disableDockerImageUpdate,
-            method: self
-        )
     }
 
     var description: String {

--- a/Tests/AWSLambdaPluginHelperTests/BuildBackendTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/BuildBackendTests.swift
@@ -150,13 +150,13 @@ struct AppleContainerCLIArgumentTests {
     }
 }
 
-// MARK: - CrossCompileMethod.makeBackend
+// MARK: - BuilderConfiguration.makeCrossCompileBackend
 
-@Suite("CrossCompileMethod backend selection")
-struct CrossCompileMethodBackendTests {
+@Suite("Cross-compile backend selection")
+struct CrossCompileBackendSelectionTests {
 
     @available(LambdaSwift 2.0, *)
-    static func makeConfiguration() throws -> BuilderConfiguration {
+    static func makeConfiguration(method: String) throws -> BuilderConfiguration {
         try BuilderConfiguration(arguments: [
             "--package-id", "test",
             "--package-display-name", "Test",
@@ -166,13 +166,14 @@ struct CrossCompileMethodBackendTests {
             "--output-path", "/tmp",
             "--products", "MyLambda",
             "--configuration", "release",
+            "--cross-compile", method,
         ])
     }
 
     @available(LambdaSwift 2.0, *)
     @Test("docker selects a container backend running the docker CLI")
     func dockerBackend() throws {
-        let backend = try CrossCompileMethod.docker.makeBackend(configuration: Self.makeConfiguration())
+        let backend = try Self.makeConfiguration(method: "docker").makeCrossCompileBackend()
         let container = try #require(backend as? ContainerBuildBackend)
         #expect(container.name == "docker")
         #expect(container.cli is DockerCLI)
@@ -181,18 +182,9 @@ struct CrossCompileMethodBackendTests {
     @available(LambdaSwift 2.0, *)
     @Test("container selects a container backend running the apple container CLI")
     func containerBackend() throws {
-        let backend = try CrossCompileMethod.container.makeBackend(configuration: Self.makeConfiguration())
+        let backend = try Self.makeConfiguration(method: "container").makeCrossCompileBackend()
         let container = try #require(backend as? ContainerBuildBackend)
         #expect(container.name == "container")
         #expect(container.cli is AppleContainerCLI)
-    }
-
-    @available(LambdaSwift 2.0, *)
-    @Test("unsupported methods throw", arguments: [CrossCompileMethod.swiftStaticSdk, .customSdk])
-    func unsupportedThrows(method: CrossCompileMethod) throws {
-        let config = try Self.makeConfiguration()
-        #expect(throws: BuilderErrors.self) {
-            _ = try method.makeBackend(configuration: config)
-        }
     }
 }

--- a/Tests/AWSLambdaRuntimeTests/CollectEverythingLogHandler.swift
+++ b/Tests/AWSLambdaRuntimeTests/CollectEverythingLogHandler.swift
@@ -117,16 +117,12 @@ struct CollectEverythingLogHandler: LogHandler {
         self.logStore = logStore
     }
 
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
-        self.logStore.append(level: level, message: message, metadata: self.metadata.merging(metadata ?? [:]) { $1 })
+    func log(event: LogEvent) {
+        self.logStore.append(
+            level: event.level,
+            message: event.message,
+            metadata: self.metadata.merging(event.metadata ?? [:]) { $1 }
+        )
     }
 
     subscript(metadataKey key: String) -> Logger.Metadata.Value? {


### PR DESCRIPTION
Two small follow-ups on top of the build-backend refactor (#679).

### 1. Move the cross-compile backend factory onto `BuilderConfiguration`

The call site read circularly:

```swift
backend = try configuration.crossCompileMethod.makeBackend(configuration: configuration)
```

— reaching *through* the configuration to get the method, then handing the
configuration straight back. The factory needs three values that the
configuration already owns (`crossCompileToolPath`, `baseDockerImage`,
`disableDockerImageUpdate`) plus the method, so it belongs on the configuration.

- `CrossCompileMethod` is now purely the parsed user choice (`parse` + cases +
  `description`); its `makeBackend(...)` is gone.
- `BuilderConfiguration` gains `makeCrossCompileBackend() -> any BuildBackend`,
  which reads everything it needs from `self`.
- The call site becomes `backend = try configuration.makeCrossCompileBackend()`.

No behaviour change. Also adopts explicit `any` (`any BuildBackend`,
`any ContainerCLI`).

The backend-selection tests now drive through
`BuilderConfiguration(...).makeCrossCompileBackend()` (passing `--cross-compile`).
The old "unsupported methods throw" test on the factory was dropped: unsupported
methods (`swift-static-sdk`, `custom-sdk`) are now rejected earlier, at
`BuilderConfiguration.init` via `CrossCompileMethod.parse`, and that behaviour is
already covered by `UnsupportedCrossCompileMethodsPropertyTests`.

### 2. Fix a deprecation warning in the test log handler

swift-log 1.13 added a `log(event:)` requirement to `LogHandler` and deprecated the
old `log(level:message:source:...)` method. `CollectEverythingLogHandler` (test
helper) still implemented the deprecated method, so it fell back to the deprecated
default implementation of `log(event:)`, producing a build warning. It now
implements `log(event:)` directly. (`JSONLogHandler` in the library already did.)

### Verification

- Clean build of products **and** tests: no compiler warnings originate from our
  sources (`Sources/`, `Tests/`); remaining output is only unrelated `ld:` macOS
  dylib-version notes and the pre-existing Docs.docc "unhandled file" note.
- All tests pass: 140 `AWSLambdaRuntimeTests`, 83 `AWSLambdaPluginHelperTests`.
- `swift format lint --strict` clean.
