### PR TITLE
[plugin] Retry CreateFunction on IAM propagation instead of a fixed 10s wait

### DIFF
--- a/Sources/AWSLambdaPluginHelper/Retry.swift
+++ b/Sources/AWSLambdaPluginHelper/Retry.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright SwiftAWSLambdaRuntime project authors
+// Copyright (c) Amazon.com, Inc. or its affiliates.
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Runs `operation`, retrying it while `isRetryable` accepts the thrown error.
+///
+/// AWS control-plane APIs are eventually consistent: a resource created by one call (an IAM role,
+/// an S3 bucket) may not yet be usable by the next call, surfacing as a transient error. This helper
+/// centralises the "try, wait, try again" pattern so each call site only has to describe *which*
+/// errors are transient rather than re-implement the loop, backoff, and jitter.
+///
+/// Between attempts it waits with **exponential backoff and equal jitter**: the base delay doubles
+/// each attempt (`initialDelay`, `2×`, `4×`, …) up to `maxDelay`, then a random component spreads the
+/// actual wait across the upper half of that window. Backoff bounds the load a slow dependency sees;
+/// jitter stops many concurrent deployments from retrying in lockstep (the "thundering herd").
+///
+/// The defaults are tuned for AWS eventual consistency, so the common call site is just
+/// `withRetry(isRetryable:) { ... }`.
+///
+/// - Parameters:
+///   - maxAttempts: The maximum number of times `operation` is invoked (must be >= 1).
+///   - initialDelay: The base delay before the first retry; doubles each subsequent attempt.
+///   - maxDelay: The ceiling the base delay is capped at before jitter is applied.
+///   - isRetryable: Decides whether a thrown error is transient and worth retrying.
+///   - onRetry: Invoked before each wait, with the attempt number just completed (1-based) and the
+///     error that triggered the retry. Defaults to a no-op; used for verbose progress output.
+///   - operation: The work to perform.
+/// - Returns: The value produced by the first successful `operation` invocation.
+/// - Throws: Rethrows the last error if every attempt fails or the error is not retryable.
+@available(LambdaSwift 2.0, *)
+func withRetry<Success>(
+    maxAttempts: Int = 8,
+    initialDelay: Duration = .milliseconds(500),
+    maxDelay: Duration = .seconds(20),
+    isRetryable: (any Error) -> Bool,
+    onRetry: (_ attempt: Int, _ error: any Error) -> Void = { _, _ in },
+    operation: () async throws -> Success
+) async throws -> Success {
+    precondition(maxAttempts >= 1, "maxAttempts must be at least 1")
+
+    var attempt = 0
+    while true {
+        attempt += 1
+        do {
+            return try await operation()
+        } catch {
+            guard attempt < maxAttempts, isRetryable(error) else {
+                throw error
+            }
+            onRetry(attempt, error)
+            let delay = backoffDelay(
+                attempt: attempt,
+                initialDelay: initialDelay,
+                maxDelay: maxDelay,
+                jitter: Double.random(in: 0...1)
+            )
+            try await Task.sleep(for: delay)
+        }
+    }
+}
+
+/// Computes the wait before a given retry using exponential backoff with equal jitter.
+///
+/// The base delay is `initialDelay × 2^(attempt - 1)`, capped at `maxDelay`. Equal jitter then keeps
+/// the lower half of that window fixed and randomises the upper half:
+/// `base/2 + jitter × base/2`. With `jitter` in `0...1` the result lies in `[base/2, base]`, which
+/// preserves a meaningful minimum wait while still de-synchronising concurrent callers.
+///
+/// Factored out of ``withRetry(maxAttempts:initialDelay:maxDelay:isRetryable:onRetry:operation:)`` so
+/// the backoff curve and jitter can be unit tested deterministically by supplying a fixed `jitter`.
+///
+/// - Parameters:
+///   - attempt: The 1-based number of the attempt that just failed.
+///   - initialDelay: The base delay for the first retry.
+///   - maxDelay: The ceiling applied to the exponential base before jitter.
+///   - jitter: A value in `0...1` selecting where in the upper half of the window the wait falls.
+@available(LambdaSwift 2.0, *)
+func backoffDelay(attempt: Int, initialDelay: Duration, maxDelay: Duration, jitter: Double) -> Duration {
+    // Clamp the exponent so the shift cannot overflow on a large maxAttempts.
+    let exponent = min(max(attempt, 1) - 1, 30)
+    let exponential = initialDelay * Double(1 << exponent)
+    let capped = min(exponential, maxDelay)
+    let clampedJitter = min(max(jitter, 0), 1)
+    return capped / 2 + (capped / 2) * clampedJitter
+}

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer.swift
@@ -305,8 +305,24 @@ struct Deployer {
             packageType: .zip
         )
 
+        // A just-created IAM role is not always assumable by Lambda immediately: IAM is eventually
+        // consistent, so CreateFunction can fail with InvalidParameterValueException ("The role
+        // defined for the function cannot be assumed by Lambda") until the role propagates. Retry on
+        // that specific transient error with a short backoff, up to a bounded ceiling, instead of
+        // unconditionally waiting for propagation before every create.
         do {
-            let response = try await lambdaClient.createFunction(request)
+            let response = try await withRetry(
+                isRetryable: { self.isRoleNotYetAssumable($0) },
+                onRetry: { attempt, _ in
+                    if verbose {
+                        print(
+                            "[verbose] IAM role not yet assumable by Lambda (attempt \(attempt)); retrying..."
+                        )
+                    }
+                }
+            ) {
+                try await lambdaClient.createFunction(request)
+            }
             if verbose {
                 print("[verbose] Lambda function '\(name)' created successfully")
                 if let arn = response.functionArn {
@@ -321,6 +337,22 @@ struct Deployer {
                 message: error.message ?? error.errorCode
             )
         }
+    }
+
+    /// Whether a CreateFunction error indicates the execution role has not yet propagated and is
+    /// therefore not yet assumable by Lambda — a transient, eventually-consistent IAM condition that
+    /// is worth retrying.
+    func isRoleNotYetAssumable(_ error: any Error) -> Bool {
+        guard let error = error as? LambdaErrorType else { return false }
+        return self.isRoleNotYetAssumable(errorCode: error.errorCode, message: error.message)
+    }
+
+    /// String-level predicate behind ``isRoleNotYetAssumable(_:)``, split out so it can be unit
+    /// tested without constructing a `LambdaErrorType` (whose error context is not publicly
+    /// constructible).
+    func isRoleNotYetAssumable(errorCode: String, message: String?) -> Bool {
+        errorCode == "InvalidParameterValueException"
+            && (message?.contains("cannot be assumed by Lambda") ?? false)
     }
 
     /// Updates an existing Lambda function's code.
@@ -1050,17 +1082,9 @@ struct Deployer {
             print("[verbose] Attached AWSLambdaBasicExecutionRole policy to '\(roleName)'")
         }
 
-        // Wait for role propagation — IAM is eventually consistent and the role
-        // may not be usable by Lambda immediately after creation.
-        if verbose {
-            print("[verbose] Waiting 10 seconds for IAM role propagation...")
-        }
-        try await Task.sleep(for: .seconds(10))
-
-        if verbose {
-            print("[verbose] IAM role '\(roleName)' is ready")
-        }
-
+        // No fixed propagation wait here. IAM is eventually consistent, so a freshly created role
+        // may not be assumable by Lambda for a short window; CreateFunction retries on that specific
+        // error (see `createFunction`), which is typically far faster than an unconditional sleep.
         return roleARN
     }
 

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer.swift
@@ -323,13 +323,16 @@ struct Deployer {
                 onRetry: { attempt, _ in
                     if verbose {
                         print(
-                            "[verbose] IAM role not yet assumable by Lambda (attempt \(attempt)); retrying..."
+                            "[verbose] IAM role not yet assumable by Lambda (attempt \(attempt)/15); retrying..."
                         )
+                    } else {
+                        print("Waiting for the role (\(attempt)/15)...")
                     }
+                },
+                operation: {
+                    try await lambdaClient.createFunction(request)
                 }
-            ) {
-                try await lambdaClient.createFunction(request)
-            }
+            )
             if verbose {
                 print("[verbose] Lambda function '\(name)' created successfully")
                 if let arn = response.functionArn {

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer.swift
@@ -307,11 +307,18 @@ struct Deployer {
 
         // A just-created IAM role is not always assumable by Lambda immediately: IAM is eventually
         // consistent, so CreateFunction can fail with InvalidParameterValueException ("The role
-        // defined for the function cannot be assumed by Lambda") until the role propagates. Retry on
-        // that specific transient error with a short backoff, up to a bounded ceiling, instead of
-        // unconditionally waiting for propagation before every create.
+        // defined for the function cannot be assumed by Lambda") until the role propagates.
+        //
+        // Role propagation is a fixed-time event (typically a few seconds), not an overloaded
+        // dependency, so we poll quickly with a low delay ceiling rather than letting the default
+        // exponential backoff grow coarse: that catches readiness within ~1s of it happening instead
+        // of overshooting into long late-stage waits. The high attempt count keeps a generous ceiling
+        // as a safety net.
         do {
             let response = try await withRetry(
+                maxAttempts: 15,
+                initialDelay: .milliseconds(500),
+                maxDelay: .seconds(2),
                 isRetryable: { self.isRoleNotYetAssumable($0) },
                 onRetry: { attempt, _ in
                     if verbose {

--- a/Tests/AWSLambdaPluginHelperTests/DeployerIAMRoleTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/DeployerIAMRoleTests.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright SwiftAWSLambdaRuntime project authors
+// Copyright (c) Amazon.com, Inc. or its affiliates.
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import AWSLambdaPluginHelper
+
+@Suite("Deployer IAM role propagation detection")
+struct DeployerIAMRoleTests {
+
+    @available(LambdaSwift 2.0, *)
+    @Test("InvalidParameterValueException about an unassumable role is retryable")
+    func roleNotYetAssumableIsRetryable() {
+        let deployer = Deployer()
+        #expect(
+            deployer.isRoleNotYetAssumable(
+                errorCode: "InvalidParameterValueException",
+                message: "The role defined for the function cannot be assumed by Lambda."
+            )
+        )
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("A different InvalidParameterValueException is not retried")
+    func unrelatedInvalidParameterIsNotRetryable() {
+        let deployer = Deployer()
+        #expect(
+            !deployer.isRoleNotYetAssumable(
+                errorCode: "InvalidParameterValueException",
+                message: "1 validation error detected: value at 'memorySize' failed to satisfy constraint."
+            )
+        )
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("A matching message under a different error code is not retried")
+    func differentErrorCodeIsNotRetryable() {
+        let deployer = Deployer()
+        #expect(
+            !deployer.isRoleNotYetAssumable(
+                errorCode: "ResourceConflictException",
+                message: "The role defined for the function cannot be assumed by Lambda."
+            )
+        )
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("A nil message is not retried")
+    func missingMessageIsNotRetryable() {
+        let deployer = Deployer()
+        #expect(
+            !deployer.isRoleNotYetAssumable(
+                errorCode: "InvalidParameterValueException",
+                message: nil
+            )
+        )
+    }
+}

--- a/Tests/AWSLambdaPluginHelperTests/RetryTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/RetryTests.swift
@@ -30,11 +30,12 @@ struct RetryTests {
         let result = try await withRetry(
             maxAttempts: 3,
             initialDelay: .zero,
-            isRetryable: { _ in true }
-        ) {
-            attempts.increment()
-            return 42
-        }
+            isRetryable: { _ in true },
+            operation: {
+                attempts.increment()
+                return 42
+            }
+        )
         #expect(result == 42)
         #expect(attempts.value == 1)
     }
@@ -46,12 +47,13 @@ struct RetryTests {
         let result = try await withRetry(
             maxAttempts: 5,
             initialDelay: .zero,
-            isRetryable: { $0 is Transient }
-        ) {
-            attempts.increment()
-            if attempts.value < 3 { throw Transient() }
-            return "ok"
-        }
+            isRetryable: { $0 is Transient },
+            operation: {
+                attempts.increment()
+                if attempts.value < 3 { throw Transient() }
+                return "ok"
+            }
+        )
         #expect(result == "ok")
         #expect(attempts.value == 3)
     }
@@ -64,11 +66,12 @@ struct RetryTests {
             try await withRetry(
                 maxAttempts: 3,
                 initialDelay: .zero,
-                isRetryable: { $0 is Transient }
-            ) {
-                attempts.increment()
-                throw Transient()
-            }
+                isRetryable: { $0 is Transient },
+                operation: {
+                    attempts.increment()
+                    throw Transient()
+                }
+            )
         }
         #expect(attempts.value == 3)
     }
@@ -81,11 +84,12 @@ struct RetryTests {
             try await withRetry(
                 maxAttempts: 5,
                 initialDelay: .zero,
-                isRetryable: { $0 is Transient }
-            ) {
-                attempts.increment()
-                throw Fatal()
-            }
+                isRetryable: { $0 is Transient },
+                operation: {
+                    attempts.increment()
+                    throw Fatal()
+                }
+            )
         }
         #expect(attempts.value == 1)
     }
@@ -99,12 +103,13 @@ struct RetryTests {
             maxAttempts: 4,
             initialDelay: .zero,
             isRetryable: { $0 is Transient },
-            onRetry: { _, _ in retries.increment() }
-        ) {
-            attempts.increment()
-            if attempts.value < 3 { throw Transient() }
-            return 0
-        }
+            onRetry: { _, _ in retries.increment() },
+            operation: {
+                attempts.increment()
+                if attempts.value < 3 { throw Transient() }
+                return 0
+            }
+        )
         // Two failures before the third, successful attempt → two retry callbacks.
         #expect(retries.value == 2)
     }

--- a/Tests/AWSLambdaPluginHelperTests/RetryTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/RetryTests.swift
@@ -1,0 +1,162 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright SwiftAWSLambdaRuntime project authors
+// Copyright (c) Amazon.com, Inc. or its affiliates.
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import AWSLambdaPluginHelper
+
+@Suite("withRetry")
+struct RetryTests {
+
+    private struct Transient: Error {}
+    private struct Fatal: Error {}
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Returns immediately when the operation succeeds on the first attempt")
+    func succeedsFirstAttempt() async throws {
+        let attempts = Counter()
+        let result = try await withRetry(
+            maxAttempts: 3,
+            initialDelay: .zero,
+            isRetryable: { _ in true }
+        ) {
+            attempts.increment()
+            return 42
+        }
+        #expect(result == 42)
+        #expect(attempts.value == 1)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Retries a transient failure and then succeeds")
+    func retriesThenSucceeds() async throws {
+        let attempts = Counter()
+        let result = try await withRetry(
+            maxAttempts: 5,
+            initialDelay: .zero,
+            isRetryable: { $0 is Transient }
+        ) {
+            attempts.increment()
+            if attempts.value < 3 { throw Transient() }
+            return "ok"
+        }
+        #expect(result == "ok")
+        #expect(attempts.value == 3)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Stops after maxAttempts and rethrows the last error")
+    func exhaustsAttempts() async throws {
+        let attempts = Counter()
+        await #expect(throws: Transient.self) {
+            try await withRetry(
+                maxAttempts: 3,
+                initialDelay: .zero,
+                isRetryable: { $0 is Transient }
+            ) {
+                attempts.increment()
+                throw Transient()
+            }
+        }
+        #expect(attempts.value == 3)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Does not retry an error the predicate rejects")
+    func rethrowsNonRetryableImmediately() async throws {
+        let attempts = Counter()
+        await #expect(throws: Fatal.self) {
+            try await withRetry(
+                maxAttempts: 5,
+                initialDelay: .zero,
+                isRetryable: { $0 is Transient }
+            ) {
+                attempts.increment()
+                throw Fatal()
+            }
+        }
+        #expect(attempts.value == 1)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Reports each retry through onRetry")
+    func reportsRetries() async throws {
+        let attempts = Counter()
+        let retries = Counter()
+        _ = try await withRetry(
+            maxAttempts: 4,
+            initialDelay: .zero,
+            isRetryable: { $0 is Transient },
+            onRetry: { _, _ in retries.increment() }
+        ) {
+            attempts.increment()
+            if attempts.value < 3 { throw Transient() }
+            return 0
+        }
+        // Two failures before the third, successful attempt → two retry callbacks.
+        #expect(retries.value == 2)
+    }
+
+    // MARK: - backoffDelay
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Base delay doubles each attempt before jitter")
+    func backoffGrowsExponentially() {
+        let initial = Duration.milliseconds(500)
+        let maxDelay = Duration.seconds(60)
+        // jitter == 1 selects the top of the window, i.e. the full (uncapped) base delay.
+        #expect(backoffDelay(attempt: 1, initialDelay: initial, maxDelay: maxDelay, jitter: 1) == .milliseconds(500))
+        #expect(backoffDelay(attempt: 2, initialDelay: initial, maxDelay: maxDelay, jitter: 1) == .seconds(1))
+        #expect(backoffDelay(attempt: 3, initialDelay: initial, maxDelay: maxDelay, jitter: 1) == .seconds(2))
+        #expect(backoffDelay(attempt: 4, initialDelay: initial, maxDelay: maxDelay, jitter: 1) == .seconds(4))
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Base delay is capped at maxDelay")
+    func backoffIsCapped() {
+        let delay = backoffDelay(
+            attempt: 20,
+            initialDelay: .milliseconds(500),
+            maxDelay: .seconds(10),
+            jitter: 1
+        )
+        #expect(delay == .seconds(10))
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Equal jitter keeps the wait within the upper half of the window")
+    func jitterStaysWithinBounds() {
+        let initial = Duration.seconds(4)
+        // attempt 1, jitter 0 → base/2; jitter 1 → base. Window is [2s, 4s].
+        #expect(backoffDelay(attempt: 1, initialDelay: initial, maxDelay: .seconds(60), jitter: 0) == .seconds(2))
+        #expect(backoffDelay(attempt: 1, initialDelay: initial, maxDelay: .seconds(60), jitter: 0.5) == .seconds(3))
+        #expect(backoffDelay(attempt: 1, initialDelay: initial, maxDelay: .seconds(60), jitter: 1) == .seconds(4))
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("Out-of-range jitter is clamped to 0...1")
+    func jitterIsClamped() {
+        let initial = Duration.seconds(4)
+        #expect(backoffDelay(attempt: 1, initialDelay: initial, maxDelay: .seconds(60), jitter: -5) == .seconds(2))
+        #expect(backoffDelay(attempt: 1, initialDelay: initial, maxDelay: .seconds(60), jitter: 5) == .seconds(4))
+    }
+}
+
+/// Minimal mutable counter for asserting attempt counts within `withRetry`'s non-escaping,
+/// non-concurrent operation closure.
+private final class Counter {
+    private(set) var value = 0
+    func increment() { self.value += 1 }
+}


### PR DESCRIPTION
## Motivation

On first-time `lambda-deploy`, the step printed as `Resolving IAM role...` always took ~10 seconds. After creating the execution role, `createIAMRole` ended with an unconditional `Task.sleep(for: .seconds(10))` to wait out IAM's eventual consistency — so every new-role deploy paid a flat 10s regardless of how quickly the role actually propagated.

The wait exists for a real reason: a freshly created IAM role is not always assumable by Lambda immediately, so `CreateFunction` can fail with `InvalidParameterValueException` ("The role defined for the function cannot be assumed by Lambda") until the role propagates. But a fixed sleep is the worst of both worlds — slow for the common case, and still only a guess.

## Change

Replace the fixed sleep with a bounded **retry** around `CreateFunction`, and introduce a reusable retry primitive.

- **`withRetry(...)`** (`Sources/AWSLambdaPluginHelper/Retry.swift`) — a general retry utility:
  - **Exponential backoff with equal jitter.** The base delay doubles each attempt (`initialDelay`, 2×, 4×, …) capped at `maxDelay`; jitter then randomises the actual wait within `[base/2, base]`. Backoff bounds the load on a slow dependency; jitter prevents many concurrent deployments from retrying in lockstep (thundering herd).
  - **Sensible defaults** (`maxAttempts: 8`, `initialDelay: 500ms`, `maxDelay: 20s`) so the common call site stays clean: `withRetry(isRetryable:) { ... }`.
  - The delay maths is factored into `backoffDelay(attempt:initialDelay:maxDelay:jitter:)` so the curve and jitter are unit-tested deterministically (randomness is injected only inside `withRetry`).

- **`Deployer.createFunction`** now wraps the API call in `withRetry`, retrying only the specific transient error (`InvalidParameterValueException` + "cannot be assumed by Lambda"). The flat 10s sleep in `createIAMRole` is removed. Most deploys now proceed as soon as the role propagates (often < 2s) instead of always waiting 10s.

### Note on scope

I searched the deploy plugin for other hand-rolled retry/poll loops to migrate behind the utility — there were none (the only other loop is the stdout read loop in `Process.swift`, which is not a retry). `withRetry` is now the single retry primitive, ready for future call sites.

## Testing

- `RetryTests` — success-first-attempt, retry-then-succeed, exhaustion, non-retryable-rethrow, `onRetry` callback, plus deterministic `backoffDelay` coverage (exponential growth, `maxDelay` cap, jitter bounds, out-of-range jitter clamping).
- `DeployerIAMRoleTests` — the transient-error detection predicate (matching error, unrelated `InvalidParameterValueException`, different error code, nil message).
- Built and all 13 tests pass on macOS and in the `swiftlang/swift:nightly-6.4.x-bookworm` (Linux) container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)