### PR TITLE
[plugin] Enforce build/deploy architecture consistency (#683)

### DIFF
--- a/Plugins/AWSLambdaBuilder/Plugin.swift
+++ b/Plugins/AWSLambdaBuilder/Plugin.swift
@@ -34,14 +34,20 @@ struct AWSLambdaBuilder: CommandPlugin {
         // The helper requires --configuration; the plugin supplies the default. Validation of the
         // value itself is left to the helper.
         let configurationArgument = argumentExtractor.extractOption(named: "configuration")
-        // `--container-cli` is a deprecated alias for `--cross-compile`.
         let crossCompileArgument = argumentExtractor.extractOption(named: "cross-compile")
-        let containerCliArgument = argumentExtractor.extractOption(named: "container-cli")
+        // `--container-cli` only exists on the deprecated `archive` command. Reject it here rather
+        // than let it fall through to the helper and be silently ignored (which would build with the
+        // wrong CLI). The user is told to use the canonical `--cross-compile` instead.
+        guard argumentExtractor.extractOption(named: "container-cli").isEmpty else {
+            throw BuilderErrors.invalidArgument(
+                "'--container-cli' is not supported by lambda-build. Use '--cross-compile <docker|container>' instead."
+            )
+        }
 
         // Resolve the container CLI that matches the requested cross-compilation method. The plugin
         // sandbox can only run tools it resolves up front, so we must pick the right binary here:
         // `container` for `--cross-compile container`, `docker` otherwise.
-        let crossCompileMethod = (crossCompileArgument.first ?? containerCliArgument.first)?.lowercased()
+        let crossCompileMethod = crossCompileArgument.first?.lowercased()
         let containerCLIToolName = crossCompileMethod == "container" ? "container" : "docker"
         let containerToolPath = try context.tool(named: containerCLIToolName).url
         let zipToolPath = try context.tool(named: "zip").url

--- a/Plugins/AWSLambdaDeployer/Plugin.swift
+++ b/Plugins/AWSLambdaDeployer/Plugin.swift
@@ -29,10 +29,16 @@ struct AWSLambdaDeployer: CommandPlugin {
         var argumentExtractor = ArgumentExtractor(arguments)
         let productsArgument = argumentExtractor.extractOption(named: "products")
         // `--cross-compile` selects the container CLI used to push an OCI image to ECR (docker or
-        // container). The plugin sandbox can only run tools it resolves up front, so the matching
-        // binary is resolved here and forwarded as --cross-compile-tool-path. For a ZIP deploy this
-        // is unused; resolving docker by default is harmless.
+        // container).
         let crossCompileArgument = argumentExtractor.extractOption(named: "cross-compile")
+        // `--container-cli` only exists on the deprecated `archive` command. Reject it here rather
+        // than let it fall through to the helper and be silently ignored (which would push with the
+        // wrong CLI). The user is told to use the canonical `--cross-compile` instead.
+        guard argumentExtractor.extractOption(named: "container-cli").isEmpty else {
+            throw DeployerPluginErrors.invalidArgument(
+                "'--container-cli' is not supported by lambda-deploy. Use '--cross-compile <docker|container>' instead."
+            )
+        }
 
         let products: [Product]
         if !productsArgument.isEmpty {
@@ -44,17 +50,20 @@ struct AWSLambdaDeployer: CommandPlugin {
         let productNames = products.map { $0.name }.joined(separator: ",")
 
         let crossCompile = crossCompileArgument.first?.lowercased()
-        let containerCLIToolName = crossCompile == "container" ? "container" : "docker"
-        // Best-effort: a container CLI may not be installed for a plain ZIP deploy, so don't fail
-        // here if it can't be resolved — the helper only needs it for an image artifact.
-        let containerToolPath = try? context.tool(named: containerCLIToolName).url
 
         var args = ["deploy", "--products", productNames]
         if let crossCompile {
             args += ["--cross-compile", crossCompile]
         }
-        if let containerToolPath {
-            args += ["--cross-compile-tool-path", containerToolPath.path]
+        // The CLI flavor to use is only known after the helper reads the build manifest, and the
+        // plugin sandbox can only run tools it resolves up front. So resolve every container CLI that
+        // is installed and forward each as `--cross-compile-tool-path <name>=<path>`; the helper then
+        // picks the path matching the CLI it selects. Best-effort: a plain ZIP deploy needs none, so
+        // a CLI that can't be resolved is simply omitted.
+        for cliName in ["docker", "container"] {
+            if let toolPath = try? context.tool(named: cliName).url {
+                args += ["--cross-compile-tool-path", "\(cliName)=\(toolPath.path)"]
+            }
         }
         args += argumentExtractor.remainingArguments
 
@@ -74,4 +83,15 @@ struct AWSLambdaDeployer: CommandPlugin {
         }
     }
 
+}
+
+private enum DeployerPluginErrors: Error, CustomStringConvertible {
+    case invalidArgument(String)
+
+    var description: String {
+        switch self {
+        case .invalidArgument(let description):
+            return description
+        }
+    }
 }

--- a/Sources/AWSLambdaPluginHelper/lambda-build/ArchiveBackends/ZipArchiveBackend.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/ArchiveBackends/ZipArchiveBackend.swift
@@ -30,6 +30,10 @@ struct ZipArchiveBackend: ArchiveBackend {
     /// The resolved path to the `zip` tool.
     let zipToolPath: URL
 
+    /// The architecture the binaries were built for, recorded in the build manifest so the deploy
+    /// step deploys the function for the architecture it was actually built for.
+    let architecture: BuildArchitecture
+
     // TODO: explore using ziplib or similar instead of shelling out
     func archive(
         products: [String: URL],
@@ -121,7 +125,7 @@ struct ZipArchiveBackend: ArchiveBackend {
             // (package type + architecture) instead of re-deriving everything from the path.
             try BuildManifest.zip(
                 product: product,
-                architecture: .host,
+                architecture: self.architecture,
                 zipPath: zipfilePath.path()
             ).write(into: workingDirectory)
 

--- a/Sources/AWSLambdaPluginHelper/lambda-build/BuildArchitecture.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/BuildArchitecture.swift
@@ -15,9 +15,9 @@
 
 /// The target CPU architecture an artifact is built for.
 ///
-/// An OCI image bakes in a single architecture, so the build step needs to know which one to
-/// target. Today this defaults to the host architecture; a user-facing `--architecture` flag and
-/// build-manifest plumbing are tracked separately (issue #683) and will set this explicitly.
+/// Set explicitly by `--architecture` (defaulting to the host architecture) and recorded in the
+/// build manifest so `lambda-deploy` deploys the function for the architecture the binary was
+/// actually built for. Both the ZIP and OCI archive backends target this single architecture.
 @available(LambdaSwift 2.0, *)
 enum BuildArchitecture: String, Codable, CustomStringConvertible {
     case x64
@@ -32,20 +32,17 @@ enum BuildArchitecture: String, Codable, CustomStringConvertible {
         #endif
     }
 
-    /// The value docker's `--platform` flag expects (`linux/amd64`, `linux/arm64`).
-    var dockerPlatform: String {
-        switch self {
-        case .x64: return "linux/amd64"
-        case .arm64: return "linux/arm64"
+    /// Parses the `--architecture` value, defaulting to the host architecture when omitted.
+    static func parse(_ value: String?) throws -> Self {
+        guard let value else {
+            return .host
         }
-    }
-
-    /// The value Apple `container`'s `--arch` flag expects (`amd64`, `arm64`).
-    var containerArch: String {
-        switch self {
-        case .x64: return "amd64"
-        case .arm64: return "arm64"
+        guard let architecture = BuildArchitecture(rawValue: value.lowercased()) else {
+            throw BuilderErrors.invalidArgument(
+                "invalid architecture '\(value)'. Use 'x64' or 'arm64'."
+            )
         }
+        return architecture
     }
 
     var description: String {

--- a/Sources/AWSLambdaPluginHelper/lambda-build/BuildBackends/AppleContainerCLI.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/BuildBackends/AppleContainerCLI.swift
@@ -23,19 +23,29 @@
 struct AppleContainerCLI: ContainerCLI {
     let executableName = "container"
 
-    func pullArguments(image: String) -> [String] {
-        ["image", "pull", image]
+    /// The value Apple `container`'s `--arch` flag expects (`amd64`, `arm64`).
+    func arch(for architecture: BuildArchitecture) -> String {
+        switch architecture {
+        case .x64: return "amd64"
+        case .arm64: return "arm64"
+        }
+    }
+
+    func pullArguments(image: String, architecture: BuildArchitecture) -> [String] {
+        ["image", "pull", "--platform", "linux/\(self.arch(for: architecture))", image]
     }
 
     func runArguments(
         baseImage: String,
+        architecture: BuildArchitecture,
         workingDirectory: String,
         mounts: [String],
         env: [String: String]?,
         command: String
     ) -> [String] {
-        // container's runtime needs a bit more memory than the default
-        var args: [String] = ["run", "--memory", "4G", "--rm"]
+        // container's runtime needs a bit more memory than the default. `--arch` selects the
+        // container's CPU architecture, which is what the in-container `swift build` compiles for.
+        var args: [String] = ["run", "--arch", self.arch(for: architecture), "--memory", "4G", "--rm"]
         for mount in mounts {
             args += ["-v", mount]
         }
@@ -59,7 +69,7 @@ struct AppleContainerCLI: ContainerCLI {
         // explicit `-f`. `--arch` selects the single target architecture.
         [
             "build",
-            "--arch", architecture.containerArch,
+            "--arch", self.arch(for: architecture),
             "-f", dockerfile,
             "-t", tag,
             contextDir,

--- a/Sources/AWSLambdaPluginHelper/lambda-build/BuildBackends/ContainerBuildBackend.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/BuildBackends/ContainerBuildBackend.swift
@@ -32,6 +32,10 @@ struct ContainerBuildBackend: BuildBackend {
     let baseImage: String
     let disableImageUpdate: Bool
 
+    /// The CPU architecture to build for. The container runs as this architecture, so the compiled
+    /// binary targets it; recorded in the build manifest and matched against the deploy architecture.
+    let architecture: BuildArchitecture
+
     /// The cross-compile method that selected this backend, retained for error reporting.
     let method: CrossCompileMethod
 
@@ -60,7 +64,7 @@ struct ContainerBuildBackend: BuildBackend {
             print("updating \"\(self.baseImage)\" image")
             try Utils.execute(
                 executable: self.toolPath,
-                arguments: self.cli.pullArguments(image: self.baseImage),
+                arguments: self.cli.pullArguments(image: self.baseImage, architecture: self.architecture),
                 logLevel: verboseLogging ? .debug : .output
             )
         }
@@ -71,6 +75,7 @@ struct ContainerBuildBackend: BuildBackend {
             executable: self.toolPath,
             arguments: self.cli.runArguments(
                 baseImage: self.baseImage,
+                architecture: self.architecture,
                 workingDirectory: "/workspace",
                 mounts: ["\(packageDirectory.path()):/workspace"],
                 env: nil,
@@ -103,6 +108,7 @@ struct ContainerBuildBackend: BuildBackend {
                     executable: self.toolPath,
                     arguments: self.cli.runArguments(
                         baseImage: self.baseImage,
+                        architecture: self.architecture,
                         workingDirectory: "/workspace/\(slice.joined(separator: "/"))",
                         mounts: ["\(packageDirectory.path())../..:/workspace"],
                         env: ["LAMBDA_USE_LOCAL_DEPS": localPath],
@@ -115,6 +121,7 @@ struct ContainerBuildBackend: BuildBackend {
                     executable: self.toolPath,
                     arguments: self.cli.runArguments(
                         baseImage: self.baseImage,
+                        architecture: self.architecture,
                         workingDirectory: "/workspace",
                         mounts: ["\(packageDirectory.path()):/workspace"],
                         env: nil,

--- a/Sources/AWSLambdaPluginHelper/lambda-build/BuildBackends/ContainerCLI.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/BuildBackends/ContainerCLI.swift
@@ -27,19 +27,23 @@ protocol ContainerCLI {
     /// The name of the executable to resolve and run (e.g. "docker", "container").
     var executableName: String { get }
 
-    /// The arguments to pull (update) the given base image.
-    func pullArguments(image: String) -> [String]
+    /// The arguments to pull (update) the given base image for a target architecture.
+    func pullArguments(image: String, architecture: BuildArchitecture) -> [String]
 
     /// The arguments to run a command inside a container created from `baseImage`.
     ///
     /// - Parameters:
     ///   - baseImage: The container image to run.
+    ///   - architecture: The CPU architecture the container should run as. The build compiles for
+    ///     the container's architecture, so this is what determines the produced binary's
+    ///     architecture and must match what the function is deployed for.
     ///   - workingDirectory: The working directory inside the container.
     ///   - mounts: Volume mounts, each in the CLI's `host:container` form.
     ///   - env: Environment variables to set inside the container, or `nil`.
     ///   - command: The shell command to execute inside the container.
     func runArguments(
         baseImage: String,
+        architecture: BuildArchitecture,
         workingDirectory: String,
         mounts: [String],
         env: [String: String]?,

--- a/Sources/AWSLambdaPluginHelper/lambda-build/BuildBackends/DockerCLI.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/BuildBackends/DockerCLI.swift
@@ -21,18 +21,27 @@
 struct DockerCLI: ContainerCLI {
     let executableName = "docker"
 
-    func pullArguments(image: String) -> [String] {
-        ["pull", image]
+    /// The value docker's `--platform` flag expects (`linux/amd64`, `linux/arm64`).
+    func platform(for architecture: BuildArchitecture) -> String {
+        switch architecture {
+        case .x64: return "linux/amd64"
+        case .arm64: return "linux/arm64"
+        }
+    }
+
+    func pullArguments(image: String, architecture: BuildArchitecture) -> [String] {
+        ["pull", "--platform", self.platform(for: architecture), image]
     }
 
     func runArguments(
         baseImage: String,
+        architecture: BuildArchitecture,
         workingDirectory: String,
         mounts: [String],
         env: [String: String]?,
         command: String
     ) -> [String] {
-        var args: [String] = ["run", "--rm"]
+        var args: [String] = ["run", "--platform", self.platform(for: architecture), "--rm"]
         for mount in mounts {
             args += ["-v", mount]
         }
@@ -53,7 +62,7 @@ struct DockerCLI: ContainerCLI {
     ) -> [String] {
         [
             "build",
-            "--platform", architecture.dockerPlatform,
+            "--platform", self.platform(for: architecture),
             "-f", dockerfile,
             "-t", tag,
             contextDir,

--- a/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
@@ -38,6 +38,17 @@ struct Builder {
         // otherwise cross-compile using the backend chosen by --cross-compile.
         let backend: any BuildBackend
         if self.isAmazonLinux(.al2) || self.isAmazonLinux(.al2023) {
+            // A native build compiles for the host architecture only; it cannot target another one.
+            // Recording a mismatched architecture in the manifest would recreate the very bug the
+            // --architecture flag exists to prevent, so reject an explicit cross-architecture request.
+            guard configuration.architecture == .host else {
+                throw BuilderErrors.invalidArgument(
+                    "cannot build for '\(configuration.architecture)' on a '\(BuildArchitecture.host)' "
+                        + "Amazon Linux host: a native build targets the host architecture only. "
+                        + "Build on a '\(configuration.architecture)' host, or cross-compile from a non-Amazon "
+                        + "Linux host (docker or container)."
+                )
+            }
             backend = NativeBuildBackend()
         } else {
             backend = try configuration.makeCrossCompileBackend()
@@ -115,6 +126,7 @@ struct Builder {
                                                        [--disable-docker-image-update]
                                                        [--cross-compile <docker | container | swift-static-sdk | custom-sdk>]
                                                        [--archive-format <zip | oci>]
+                                                       [--architecture <x64 | arm64>]
                                                        [--base-oci-image <oci_image_name>]
                                                        [--no-strip]
 
@@ -145,6 +157,11 @@ struct Builder {
                                           Values: zip, oci
                                           (default is zip)
                                           oci builds an OCI image (deploy support: see lambda-deploy).
+            --architecture <arch>         The CPU architecture to build for.
+                                          Values: x64, arm64
+                                          (default: host architecture)
+                                          Recorded in the build manifest; lambda-deploy deploys the
+                                          function for this architecture.
             --base-oci-image <name>       The base image for the OCI image (--archive-format oci).
                                           (default: public.ecr.aws/amazonlinux/amazonlinux:2023-minimal)
                                           Use a glibc-compatible Amazon Linux 2023 base.
@@ -168,6 +185,7 @@ struct BuilderConfiguration: CustomStringConvertible {
     public let disableDockerImageUpdate: Bool
     public let crossCompileMethod: CrossCompileMethod
     public let archiveFormat: ArchiveFormat
+    public let architecture: BuildArchitecture
     public let baseOCIImage: String
     public let noStrip: Bool
     public let explicitAL2Image: Bool
@@ -198,6 +216,7 @@ struct BuilderConfiguration: CustomStringConvertible {
         let crossCompileArgument = argumentExtractor.extractOption(named: "cross-compile")
         let containerCliArgument = argumentExtractor.extractOption(named: "container-cli")  // deprecated alias
         let archiveFormatArgument = argumentExtractor.extractOption(named: "archive-format")
+        let architectureArgument = argumentExtractor.extractOption(named: "architecture")
         let baseOCIImageArgument = argumentExtractor.extractOption(named: "base-oci-image")
         let noStripArgument = argumentExtractor.extractFlag(named: "no-strip") > 0
         let helpArgument = argumentExtractor.extractFlag(named: "help") > 0
@@ -280,6 +299,7 @@ struct BuilderConfiguration: CustomStringConvertible {
         let resolvedCrossCompile = crossCompileArgument.first ?? containerCliArgument.first
         self.crossCompileMethod = try CrossCompileMethod.parse(resolvedCrossCompile)
         self.archiveFormat = try ArchiveFormat.parse(archiveFormatArgument.first)
+        self.architecture = try BuildArchitecture.parse(architectureArgument.first)
 
         // --base-oci-image only applies to the OCI image build; reject it for other formats rather
         // than silently ignoring it.
@@ -318,6 +338,7 @@ struct BuilderConfiguration: CustomStringConvertible {
             toolPath: self.crossCompileToolPath,
             baseImage: self.baseDockerImage,
             disableImageUpdate: self.disableDockerImageUpdate,
+            architecture: self.architecture,
             method: self.crossCompileMethod
         )
     }
@@ -341,14 +362,13 @@ struct BuilderConfiguration: CustomStringConvertible {
     func makeArchiveBackend() throws -> any ArchiveBackend {
         switch self.archiveFormat {
         case .zip:
-            return ZipArchiveBackend(zipToolPath: self.zipToolPath)
+            return ZipArchiveBackend(zipToolPath: self.zipToolPath, architecture: self.architecture)
         case .oci:
-            // An OCI image bakes in a single architecture. A user-facing --architecture flag and
-            // build-manifest plumbing are tracked under #683; until then the image targets the host.
+            // An OCI image bakes in a single architecture: the one selected by --architecture.
             return OCIArchiveBackend(
                 cli: try self.makeContainerCLI(),
                 toolPath: self.crossCompileToolPath,
-                architecture: .host,
+                architecture: self.architecture,
                 baseImage: self.baseOCIImage
             )
         }
@@ -365,6 +385,7 @@ struct BuilderConfiguration: CustomStringConvertible {
           disableDockerImageUpdate: \(self.disableDockerImageUpdate)
           crossCompileMethod: \(self.crossCompileMethod)
           archiveFormat: \(self.archiveFormat)
+          architecture: \(self.architecture)
           baseOCIImage: \(self.baseOCIImage)
           zipToolPath: \(self.zipToolPath)
           packageID: \(self.packageID)

--- a/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-build/Builder.swift
@@ -214,7 +214,6 @@ struct BuilderConfiguration: CustomStringConvertible {
         let baseDockerImageArgument = argumentExtractor.extractOption(named: "base-docker-image")
         let disableDockerImageUpdateArgument = argumentExtractor.extractFlag(named: "disable-docker-image-update") > 0
         let crossCompileArgument = argumentExtractor.extractOption(named: "cross-compile")
-        let containerCliArgument = argumentExtractor.extractOption(named: "container-cli")  // deprecated alias
         let archiveFormatArgument = argumentExtractor.extractOption(named: "archive-format")
         let architectureArgument = argumentExtractor.extractOption(named: "architecture")
         let baseOCIImageArgument = argumentExtractor.extractOption(named: "base-oci-image")
@@ -295,9 +294,7 @@ struct BuilderConfiguration: CustomStringConvertible {
             baseDockerImageArgument.first ?? "swift:\(swiftVersion.map { $0 + "-" } ?? "")amazonlinux2023"
 
         self.disableDockerImageUpdate = disableDockerImageUpdateArgument
-        // --container-cli is a deprecated alias for --cross-compile (backward compatibility)
-        let resolvedCrossCompile = crossCompileArgument.first ?? containerCliArgument.first
-        self.crossCompileMethod = try CrossCompileMethod.parse(resolvedCrossCompile)
+        self.crossCompileMethod = try CrossCompileMethod.parse(crossCompileArgument.first)
         self.archiveFormat = try ArchiveFormat.parse(archiveFormatArgument.first)
         self.architecture = try BuildArchitecture.parse(architectureArgument.first)
 

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+Configuration.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+Configuration.swift
@@ -29,7 +29,19 @@ struct DeployerConfiguration: CustomStringConvertible {
     let profile: String?
     let iamRole: String?
     let inputDirectory: URL?
+    /// The architecture resolved for deployment: the explicitly requested one, else the host.
+    /// The deployer reconciles this against the build manifest (see `explicitArchitecture`).
     let architecture: Architecture
+    /// The architecture the user requested via `--architecture`, or `nil` when omitted. When set,
+    /// the deployer treats a disagreement with the built artifact as a hard error rather than
+    /// silently deploying a function whose declared architecture does not match its binary.
+    ///
+    /// This is primarily useful for deploying an artifact that was *not* produced by `lambda-build`
+    /// (e.g. a ZIP from the legacy `archive` command, or one supplied via `--input-directory`) and
+    /// therefore has no build manifest to read the architecture from. In the normal
+    /// `lambda-build` → `lambda-deploy` flow the manifest already records the architecture, so this
+    /// flag only acts as an optional assertion against it.
+    let explicitArchitecture: Architecture?
     let products: [String]
     /// Container CLI to use for an image (OCI) deploy: `docker` or `container`. `nil` → resolved
     /// from the build manifest, falling back to docker. Mirrors `lambda-build --cross-compile`.
@@ -101,8 +113,10 @@ struct DeployerConfiguration: CustomStringConvertible {
                 throw DeployerErrors.invalidArchitecture(archString)
             }
             self.architecture = arch
+            self.explicitArchitecture = arch
         } else {
             self.architecture = .host
+            self.explicitArchitecture = nil
         }
 
         // products
@@ -127,7 +141,7 @@ struct DeployerConfiguration: CustomStringConvertible {
           profile: \(self.profile ?? "<default>")
           iamRole: \(self.iamRole ?? "<create new>")
           inputDirectory: \(self.inputDirectory?.path() ?? "<default build output>")
-          architecture: \(self.architecture.rawValue)
+          architecture: \(self.architecture.rawValue)\(self.explicitArchitecture == nil ? " <default>" : " <explicit>")
           products: \(self.products)
           crossCompile: \(self.crossCompile ?? "<from manifest>")
           crossCompileToolPath: \(self.crossCompileToolPath?.path() ?? "<none>")

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+Configuration.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+Configuration.swift
@@ -46,9 +46,11 @@ struct DeployerConfiguration: CustomStringConvertible {
     /// Container CLI to use for an image (OCI) deploy: `docker` or `container`. `nil` → resolved
     /// from the build manifest, falling back to docker. Mirrors `lambda-build --cross-compile`.
     let crossCompile: String?
-    /// Resolved path to the container CLI executable, injected by the plugin wrapper. `nil` when the
-    /// deploy is a plain ZIP (no container CLI needed).
-    let crossCompileToolPath: URL?
+    /// Resolved paths to the container CLI executables, keyed by CLI name (`docker`, `container`),
+    /// injected by the plugin wrapper. The plugin resolves every CLI it can find up front (the
+    /// sandbox only runs tools resolved ahead of time) because the CLI flavor to use is only known
+    /// after reading the build manifest. Empty for a plain ZIP deploy (no container CLI needed).
+    let crossCompileToolPaths: [String: URL]
 
     enum Architecture: String {
         case x64
@@ -123,12 +125,22 @@ struct DeployerConfiguration: CustomStringConvertible {
         self.products = productsArgument.flatMap { $0.split(separator: ",").map(String.init) }
 
         // container CLI for image deploys (nil → resolved from the build manifest)
-        self.crossCompile = crossCompileArgument.first
-        if let toolPath = crossCompileToolPathArgument.first {
-            self.crossCompileToolPath = URL(fileURLWithPath: toolPath)
-        } else {
-            self.crossCompileToolPath = nil
+        self.crossCompile = crossCompileArgument.first?.lowercased()
+
+        // Resolved container CLI paths, forwarded by the plugin as `--cross-compile-tool-path
+        // <name>=<path>` (one per available CLI). A bare path with no `name=` prefix is treated as
+        // docker for backward compatibility with older plugin wrappers and existing tests.
+        var toolPaths: [String: URL] = [:]
+        for entry in crossCompileToolPathArgument {
+            if let separator = entry.firstIndex(of: "="), separator != entry.startIndex {
+                let name = String(entry[..<separator]).lowercased()
+                let path = String(entry[entry.index(after: separator)...])
+                toolPaths[name] = URL(fileURLWithPath: path)
+            } else {
+                toolPaths["docker"] = URL(fileURLWithPath: entry)
+            }
         }
+        self.crossCompileToolPaths = toolPaths
     }
 
     var description: String {
@@ -144,7 +156,7 @@ struct DeployerConfiguration: CustomStringConvertible {
           architecture: \(self.architecture.rawValue)\(self.explicitArchitecture == nil ? " <default>" : " <explicit>")
           products: \(self.products)
           crossCompile: \(self.crossCompile ?? "<from manifest>")
-          crossCompileToolPath: \(self.crossCompileToolPath?.path() ?? "<none>")
+          crossCompileToolPaths: \(self.crossCompileToolPaths.isEmpty ? "<none>" : self.crossCompileToolPaths.map { "\($0.key)=\($0.value.path())" }.sorted().joined(separator: ", "))
         }
         """
     }

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+ECR.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+ECR.swift
@@ -54,16 +54,8 @@ extension Deployer {
             throw DeployerErrors.ecrError("build manifest for '\(functionName)' has no image tag")
         }
 
-        // Resolve the container CLI: explicit --cross-compile wins, else the manifest's recorded CLI,
-        // else docker. The plugin wrapper resolves and injects the matching tool path.
-        let cliName = configuration.crossCompile ?? manifest.containerCLI ?? "docker"
-        guard let toolPath = configuration.crossCompileToolPath else {
-            throw DeployerErrors.ecrError(
-                "deploying an image requires a container CLI; the plugin did not provide "
-                    + "--cross-compile-tool-path (is docker or container installed?)"
-            )
-        }
-        let cli: ContainerCLI = (cliName == "container") ? AppleContainerCLI() : DockerCLI()
+        // Resolve the container CLI and the matching executable path (see resolveContainerCLI).
+        let (cli, toolPath) = try Self.resolveContainerCLI(configuration: configuration, manifest: manifest)
 
         // Image architecture comes from the manifest (the image bakes in a single arch).
         let architecture = DeployerConfiguration.Architecture(rawValue: manifest.architecture.rawValue) ?? .host
@@ -148,6 +140,34 @@ extension Deployer {
             functionArn = response.functionArn
         }
         return functionArn
+    }
+
+    // MARK: - Container CLI
+
+    /// Resolves the container CLI to use for the push and its matching executable path.
+    ///
+    /// The CLI *flavor* (docker vs Apple `container`, which spell their argv differently) is chosen
+    /// as: explicit `--cross-compile` wins, else the CLI recorded in the build manifest, else docker.
+    /// The plugin wrapper resolves every installed CLI up front — it cannot know which flavor to use
+    /// before the manifest is read, and the sandbox only runs tools resolved ahead of time — and
+    /// forwards their paths keyed by name. This picks the path for the chosen flavor, so the argv
+    /// flavor and the executable can never disagree (the bug where container-style argv was run
+    /// against the docker binary, producing `docker registry login … unknown flag: --username`).
+    static func resolveContainerCLI(
+        configuration: DeployerConfiguration,
+        manifest: BuildManifest
+    ) throws -> (cli: any ContainerCLI, toolPath: URL) {
+        let cliName = configuration.crossCompile ?? manifest.containerCLI ?? "docker"
+        guard let toolPath = configuration.crossCompileToolPaths[cliName] else {
+            throw DeployerErrors.ecrError(
+                "deploying this image requires the '\(cliName)' CLI, but the plugin did not resolve "
+                    + "its path (is '\(cliName)' installed and on your PATH?). The image was built with "
+                    + "'\(manifest.containerCLI ?? "docker")'; deploy with that CLI, or pass "
+                    + "--cross-compile <docker|container> to override."
+            )
+        }
+        let cli: any ContainerCLI = (cliName == "container") ? AppleContainerCLI() : DockerCLI()
+        return (cli, toolPath)
     }
 
     // MARK: - ECR repository

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+Error.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+Error.swift
@@ -32,6 +32,7 @@ enum DeployerErrors: Error, CustomStringConvertible {
     case ecrError(String)
     case imageManifestNotAnIndex
     case packageTypeMismatch(functionName: String, existing: String, requested: String)
+    case architectureMismatch(functionName: String, requested: String, built: String)
 
     var description: String {
         switch self {
@@ -72,6 +73,17 @@ enum DeployerErrors: Error, CustomStringConvertible {
                 Suggested action: delete the function and redeploy it:
                     swift package --allow-network-connections all:443 lambda-deploy --delete
                     swift package --allow-network-connections all:443 lambda-deploy
+                """
+        case .architectureMismatch(let functionName, let requested, let built):
+            return """
+                cannot deploy function '\(functionName)' for architecture '\(requested)': the \
+                artifact produced by lambda-build was built for '\(built)'. Deploying a function \
+                whose declared architecture does not match its binary produces a function that \
+                fails at invoke time.
+
+                Suggested action: either drop --architecture to deploy what was built ('\(built)'), \
+                or rebuild for '\(requested)':
+                    swift package --allow-network-connections docker lambda-build --architecture \(requested)
                 """
         }
     }

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+Zip.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer+Zip.swift
@@ -32,6 +32,7 @@ extension Deployer {
     /// The image counterpart is ``deployImage(functionName:manifest:action:accountId:region:configuration:existingConfiguration:awsClient:lambdaClient:iamClient:)``.
     func deployZip(
         functionName: String,
+        architecture: DeployerConfiguration.Architecture,
         action: DeploymentAction,
         accountId: String,
         region: Region,
@@ -125,7 +126,7 @@ extension Deployer {
             if let bucket = s3Bucket, let key = s3Key {
                 response = try await createFunction(
                     name: functionName,
-                    architecture: configuration.architecture,
+                    architecture: architecture,
                     role: roleArn,
                     bucket: bucket,
                     key: key,
@@ -135,7 +136,7 @@ extension Deployer {
             } else {
                 response = try await createFunction(
                     name: functionName,
-                    architecture: configuration.architecture,
+                    architecture: architecture,
                     role: roleArn,
                     zipData: zipData,
                     using: lambdaClient,

--- a/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer.swift
+++ b/Sources/AWSLambdaPluginHelper/lambda-deploy/Deployer.swift
@@ -267,6 +267,17 @@ struct Deployer {
                     }
                 }
 
+                // Reconcile the deploy architecture with what lambda-build actually produced. The
+                // manifest records the built architecture; an explicit --architecture that disagrees
+                // is a hard error (it would deploy a function whose binary can't run), and when
+                // --architecture is omitted we deploy exactly what was built rather than re-defaulting
+                // to the host. Absent manifest (legacy flows) falls back to the configured value.
+                let architecture = try Self.reconcileArchitecture(
+                    configuration: configuration,
+                    manifest: manifest,
+                    functionName: functionName
+                )
+
                 if manifest?.packageType == .image {
                     functionArn = try await deployImage(
                         functionName: functionName,
@@ -283,6 +294,7 @@ struct Deployer {
                 } else {
                     functionArn = try await deployZip(
                         functionName: functionName,
+                        architecture: architecture,
                         action: action,
                         accountId: accountId,
                         region: region,
@@ -357,6 +369,34 @@ struct Deployer {
     static func readBuildManifest(functionName: String, inputDirectory: URL?) throws -> BuildManifest? {
         let dir = defaultBuildOutputDirectory(functionName: functionName, inputDirectory: inputDirectory)
         return try BuildManifest.read(from: dir)
+    }
+
+    /// Resolves the architecture to deploy for, reconciling the request with the build manifest.
+    ///
+    /// - When the manifest is absent (legacy flows, no build-manifest handoff), the configured
+    ///   architecture is used unchanged.
+    /// - When a manifest is present and the user passed `--architecture` explicitly, a disagreement
+    ///   with the built architecture is a hard error: deploying a function whose declared
+    ///   architecture does not match its binary produces a function that fails at invoke time.
+    /// - When a manifest is present and `--architecture` was omitted, the built architecture wins so
+    ///   the deploy follows what was actually built rather than re-defaulting to the host.
+    static func reconcileArchitecture(
+        configuration: DeployerConfiguration,
+        manifest: BuildManifest?,
+        functionName: String
+    ) throws -> DeployerConfiguration.Architecture {
+        guard let manifest else {
+            return configuration.architecture
+        }
+        let built = DeployerConfiguration.Architecture(rawValue: manifest.architecture.rawValue) ?? .host
+        if let requested = configuration.explicitArchitecture, requested != built {
+            throw DeployerErrors.architectureMismatch(
+                functionName: functionName,
+                requested: requested.rawValue,
+                built: built.rawValue
+            )
+        }
+        return built
     }
 
     /// Check for the presence of AWS configuration files and emit an informational
@@ -467,7 +507,9 @@ struct Deployer {
                                           ZIP archive produced by lambda-build.
                                           (default: .build/plugins/AWSLambdaBuilder/outputs/...)
             --architecture <arch>         The Lambda function architecture (x64 or arm64).
-                                          (default: host architecture - \(DeployerConfiguration.Architecture.host.rawValue))
+                                          (default: the architecture recorded in the build manifest;
+                                          host architecture - \(DeployerConfiguration.Architecture.host.rawValue) - when no manifest is present)
+                                          A value that disagrees with the built artifact is an error.
             --cross-compile <cli>         The container CLI (docker or container) used to push an
                                           OCI image to ECR. Only used for an image artifact
                                           (lambda-build --archive-format oci).

--- a/Sources/AWSLambdaRuntime/Docs.docc/deploying-with-oci.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/deploying-with-oci.md
@@ -42,7 +42,7 @@ swift package --disable-sandbox lambda-build --archive-format oci
 
 To use Apple's `container` CLI instead of Docker, add `--cross-compile container`.
 
-This compiles the executable for Amazon Linux 2023, then builds a minimal Amazon Linux 2023 image (`public.ecr.aws/amazonlinux/amazonlinux:2023-minimal`) with your binary as the `bootstrap` entrypoint. The image targets a single architecture and is tagged locally as `swift-lambda/<product>:latest`, lowercased, since OCI image references must be lowercase.
+This compiles the executable for Amazon Linux 2023, then builds a minimal Amazon Linux 2023 image (`public.ecr.aws/amazonlinux/amazonlinux:2023-minimal`) with your binary as the `bootstrap` entrypoint. The image targets a single architecture (the host by default, or the one selected with `--architecture <x64|arm64>`) and is tagged locally as `swift-lambda/<product>:latest`, lowercased, since OCI image references must be lowercase.
 
 `lambda-build --archive-format oci` builds the image locally. It does not push it. The push to Amazon ECR and the function create or update happen during `lambda-deploy`, the step that holds your AWS credentials. This matches the ZIP flow, where `lambda-build` produces the artifact and `lambda-deploy` uploads it.
 
@@ -64,7 +64,7 @@ For an image artifact, `lambda-deploy`:
 4. resolves the single-architecture child manifest by digest. Both Docker and `container` push a multi-architecture image index, which Lambda does not accept, so the deployer selects the child manifest that matches the target architecture, then
 5. creates or updates the Lambda function with `PackageType=Image`.
 
-The deployer reads the architecture and container CLI from `build-manifest.json`. To override the CLI used for the push, pass `--cross-compile <docker|container>`.
+The deployer reads the architecture and container CLI from `build-manifest.json`. To override the CLI used for the push, pass `--cross-compile <docker|container>`. Passing `--architecture` to `lambda-deploy` that disagrees with the built image is a hard error, since a container-image function's declared architecture must match the image.
 
 > Note: AWS does not allow changing the package type of an existing function, ZIP to image or back. If a function with the same name already exists with a different package type, `lambda-deploy` stops with an error. Delete the function and redeploy.
 

--- a/Sources/AWSLambdaRuntime/Docs.docc/using-the-spm-plugins.md
+++ b/Sources/AWSLambdaRuntime/Docs.docc/using-the-spm-plugins.md
@@ -102,10 +102,33 @@ swift package --allow-network-connections docker lambda-build \
 | `--disable-docker-image-update` | Do not attempt to update the Docker image. |
 | `--cross-compile <method>` | The cross-compilation method: `docker`, `container`, `swift-static-sdk`, or `custom-sdk`. (default: `docker`) `swift-static-sdk` and `custom-sdk` are not yet supported. |
 | `--archive-format <format>` | The packaging format: `zip` or `oci`. (default: `zip`) See [Building an OCI image](#Building-an-OCI-image). |
+| `--architecture <arch>` | The CPU architecture to build for: `x64` or `arm64`. (default: host architecture) Recorded in the build manifest so `lambda-deploy` deploys the function for the architecture it was built for. See [Selecting the architecture](#Selecting-the-architecture). |
 | `--base-oci-image <name>` | The base image for the OCI image when `--archive-format oci` is used. (default: `public.ecr.aws/amazonlinux/amazonlinux:2023-minimal`) |
 | `--no-strip` | Do not strip debug symbols from the binary. |
 | `--verbose` | Produce verbose output for debugging. |
 | `--help` | Show help information. |
+
+### Selecting the architecture
+
+By default `lambda-build` builds for the architecture of the machine running the
+build (`arm64` on Apple Silicon, `x64` on Intel). Pass `--architecture` to build
+for a specific architecture regardless of your host:
+
+```sh
+swift package --allow-network-connections docker lambda-build \
+  --architecture arm64
+```
+
+`arm64` (AWS Graviton) is generally cheaper and faster for Swift workloads; pick
+`x64` only if a dependency requires it.
+
+The architecture you build for is recorded in the `build-manifest.json` written
+next to the artifact. `lambda-deploy` reads it and deploys the function for that
+same architecture, so the two can never silently disagree. If you pass
+`--architecture` to `lambda-deploy` as well, it must match what was built, 
+otherwise the deploy fails fast rather than creating a function whose declared
+architecture doesn't match its binary (which would only surface as a failure at
+invoke time). See [lambda-deploy](#lambda-deploy).
 
 ### Building an OCI image
 
@@ -213,7 +236,7 @@ swift package --allow-network-connections all:443 lambda-deploy --delete
 | `--profile <profile-name>` | The named AWS profile to use for credentials and region. (default: default credential provider chain) |
 | `--iam-role <role-arn>` | The ARN of an existing IAM role for the function. (default: create a new role) |
 | `--input-directory <path>` | The directory containing the ZIP archive produced by `lambda-build`. (default: `.build/plugins/AWSLambdaBuilder/outputs/...`) |
-| `--architecture <arch>` | The function architecture, `x64` or `arm64`. (default: host architecture) |
+| `--architecture <arch>` | The function architecture, `x64` or `arm64`. (default: the architecture recorded in the build manifest; host architecture when no manifest is present) A value that disagrees with the built artifact is a hard error. |
 | `--products <list>` | The list of executable targets to deploy. (default: taken from `Package.swift`) |
 | `--verbose` | Produce verbose output for debugging. |
 | `--help` | Show help information. |

--- a/Tests/AWSLambdaPluginHelperTests/ArchiveBackendTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/ArchiveBackendTests.swift
@@ -164,7 +164,9 @@ struct ZipArchiveBackendTests {
     @available(LambdaSwift 2.0, *)
     @Test("name is zip")
     func name() {
-        #expect(ZipArchiveBackend(zipToolPath: URL(fileURLWithPath: "/usr/bin/zip")).name == "zip")
+        #expect(
+            ZipArchiveBackend(zipToolPath: URL(fileURLWithPath: "/usr/bin/zip"), architecture: .arm64).name == "zip"
+        )
     }
 
     @available(LambdaSwift 2.0, *)
@@ -183,7 +185,7 @@ struct ZipArchiveBackendTests {
         let binary = buildDir.appending(path: product)
         try Data("#!/bin/sh\necho hi\n".utf8).write(to: binary)
 
-        let backend = ZipArchiveBackend(zipToolPath: URL(fileURLWithPath: "/usr/bin/zip"))
+        let backend = ZipArchiveBackend(zipToolPath: URL(fileURLWithPath: "/usr/bin/zip"), architecture: .arm64)
         let archives = try backend.archive(
             products: [product: binary],
             outputDirectory: outputDir,
@@ -202,10 +204,12 @@ struct ZipArchiveBackendTests {
         let bootstrap = outputDir.appending(path: product).appending(path: "bootstrap")
         #expect(FileManager.default.fileExists(atPath: bootstrap.path()))
 
-        // A build manifest is written alongside the zip for the deploy hand-off.
+        // A build manifest is written alongside the zip for the deploy hand-off, recording the
+        // architecture the backend was built for.
         let manifest = try #require(try BuildManifest.read(from: outputDir.appending(path: product)))
         #expect(manifest.packageType == .zip)
         #expect(manifest.product == product)
         #expect(manifest.zipPath == zipURL.path())
+        #expect(manifest.architecture == .arm64)
     }
 }

--- a/Tests/AWSLambdaPluginHelperTests/BuildBackendTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/BuildBackendTests.swift
@@ -32,19 +32,27 @@ import Foundation
 struct DockerCLIArgumentTests {
 
     @available(LambdaSwift 2.0, *)
-    @Test("pull arguments")
+    @Test("pull arguments pin the target platform")
     func pullArguments() {
         let cli = DockerCLI()
         #expect(cli.executableName == "docker")
-        #expect(cli.pullArguments(image: "swift:amazonlinux2023") == ["pull", "swift:amazonlinux2023"])
+        #expect(
+            cli.pullArguments(image: "swift:amazonlinux2023", architecture: .arm64)
+                == ["pull", "--platform", "linux/arm64", "swift:amazonlinux2023"]
+        )
+        #expect(
+            cli.pullArguments(image: "swift:amazonlinux2023", architecture: .x64)
+                == ["pull", "--platform", "linux/amd64", "swift:amazonlinux2023"]
+        )
     }
 
     @available(LambdaSwift 2.0, *)
-    @Test("run arguments without env")
+    @Test("run arguments without env pin the target platform")
     func runArgumentsNoEnv() {
         let cli = DockerCLI()
         let args = cli.runArguments(
             baseImage: "swift:amazonlinux2023",
+            architecture: .arm64,
             workingDirectory: "/workspace",
             mounts: ["/host/pkg:/workspace"],
             env: nil,
@@ -52,7 +60,7 @@ struct DockerCLIArgumentTests {
         )
         #expect(
             args == [
-                "run", "--rm",
+                "run", "--platform", "linux/arm64", "--rm",
                 "-v", "/host/pkg:/workspace",
                 "-w", "/workspace",
                 "swift:amazonlinux2023",
@@ -67,6 +75,7 @@ struct DockerCLIArgumentTests {
         let cli = DockerCLI()
         let args = cli.runArguments(
             baseImage: "img",
+            architecture: .x64,
             workingDirectory: "/w",
             mounts: ["/a:/b", "/c:/d"],
             env: ["ZED": "1", "ABLE": "2"],
@@ -74,7 +83,7 @@ struct DockerCLIArgumentTests {
         )
         #expect(
             args == [
-                "run", "--rm",
+                "run", "--platform", "linux/amd64", "--rm",
                 "-v", "/a:/b",
                 "-v", "/c:/d",
                 "-e", "ABLE=2",
@@ -160,19 +169,27 @@ struct DockerCLIArgumentTests {
 struct AppleContainerCLIArgumentTests {
 
     @available(LambdaSwift 2.0, *)
-    @Test("pull arguments use the image subcommand")
+    @Test("pull arguments use the image subcommand and pin the platform")
     func pullArguments() {
         let cli = AppleContainerCLI()
         #expect(cli.executableName == "container")
-        #expect(cli.pullArguments(image: "swift:amazonlinux2023") == ["image", "pull", "swift:amazonlinux2023"])
+        #expect(
+            cli.pullArguments(image: "swift:amazonlinux2023", architecture: .arm64)
+                == ["image", "pull", "--platform", "linux/arm64", "swift:amazonlinux2023"]
+        )
+        #expect(
+            cli.pullArguments(image: "swift:amazonlinux2023", architecture: .x64)
+                == ["image", "pull", "--platform", "linux/amd64", "swift:amazonlinux2023"]
+        )
     }
 
     @available(LambdaSwift 2.0, *)
-    @Test("run arguments reserve memory and come before --rm")
+    @Test("run arguments select the arch, reserve memory, and come before --rm")
     func runArgumentsNoEnv() {
         let cli = AppleContainerCLI()
         let args = cli.runArguments(
             baseImage: "swift:amazonlinux2023",
+            architecture: .arm64,
             workingDirectory: "/workspace",
             mounts: ["/host/pkg:/workspace"],
             env: nil,
@@ -180,7 +197,7 @@ struct AppleContainerCLIArgumentTests {
         )
         #expect(
             args == [
-                "run", "--memory", "4G", "--rm",
+                "run", "--arch", "arm64", "--memory", "4G", "--rm",
                 "-v", "/host/pkg:/workspace",
                 "-w", "/workspace",
                 "swift:amazonlinux2023",
@@ -195,6 +212,7 @@ struct AppleContainerCLIArgumentTests {
         let cli = AppleContainerCLI()
         let args = cli.runArguments(
             baseImage: "img",
+            architecture: .x64,
             workingDirectory: "/w",
             mounts: ["/a:/b"],
             env: ["ZED": "1", "ABLE": "2"],
@@ -202,7 +220,7 @@ struct AppleContainerCLIArgumentTests {
         )
         #expect(
             args == [
-                "run", "--memory", "4G", "--rm",
+                "run", "--arch", "amd64", "--memory", "4G", "--rm",
                 "-v", "/a:/b",
                 "-e", "ABLE=2",
                 "-e", "ZED=1",

--- a/Tests/AWSLambdaPluginHelperTests/BuilderConfigurationTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/BuilderConfigurationTests.swift
@@ -93,6 +93,63 @@ struct BuilderConfigurationTests {
         #expect(config.crossCompileMethod == .docker)
     }
 
+    // MARK: - Architecture parsing (issue #683)
+
+    @available(LambdaSwift 2.0, *)
+    @Test("--architecture x64 is parsed", arguments: ["x64", "X64"])
+    func architectureX64(value: String) throws {
+        let config = try BuilderConfiguration(arguments: defaultArgs() + ["--architecture", value])
+        #expect(config.architecture == .x64)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("--architecture arm64 is parsed", arguments: ["arm64", "ARM64"])
+    func architectureArm64(value: String) throws {
+        let config = try BuilderConfiguration(arguments: defaultArgs() + ["--architecture", value])
+        #expect(config.architecture == .arm64)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("--architecture defaults to the host when omitted")
+    func architectureDefaultsToHost() throws {
+        let config = try BuilderConfiguration(arguments: defaultArgs())
+        #expect(config.architecture == .host)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("invalid --architecture throws")
+    func architectureInvalidThrows() throws {
+        #expect(throws: (any Error).self) {
+            _ = try BuilderConfiguration(arguments: defaultArgs() + ["--architecture", "mips"])
+        }
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("--architecture flows into the ZIP archive backend")
+    func architectureFlowsIntoZipBackend() throws {
+        let config = try BuilderConfiguration(arguments: defaultArgs() + ["--architecture", "arm64"])
+        let backend = try #require(try config.makeArchiveBackend() as? ZipArchiveBackend)
+        #expect(backend.architecture == .arm64)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("--architecture flows into the OCI archive backend")
+    func architectureFlowsIntoOCIBackend() throws {
+        let config = try BuilderConfiguration(
+            arguments: defaultArgs() + ["--archive-format", "oci", "--architecture", "x64"]
+        )
+        let backend = try #require(try config.makeArchiveBackend() as? OCIArchiveBackend)
+        #expect(backend.architecture == .x64)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("--architecture flows into the cross-compile build backend")
+    func architectureFlowsIntoBuildBackend() throws {
+        let config = try BuilderConfiguration(arguments: defaultArgs() + ["--architecture", "arm64"])
+        let backend = try #require(try config.makeCrossCompileBackend() as? ContainerBuildBackend)
+        #expect(backend.architecture == .arm64)
+    }
+
     // MARK: - No-strip flag (Requirements 2.5, 2.6)
 
     @available(LambdaSwift 2.0, *)

--- a/Tests/AWSLambdaPluginHelperTests/DeployerArchitectureTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/DeployerArchitectureTests.swift
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAWSLambdaRuntime open source project
+//
+// Copyright SwiftAWSLambdaRuntime project authors
+// Copyright (c) Amazon.com, Inc. or its affiliates.
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAWSLambdaRuntime project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import AWSLambdaPluginHelper
+
+/// Covers the build→deploy architecture hand-off (issue #683): the deploy step must deploy the
+/// function for the architecture the artifact was actually built for, and reject an explicit
+/// `--architecture` that disagrees with it.
+@Suite("Deployer architecture reconciliation")
+struct DeployerArchitectureTests {
+
+    @available(LambdaSwift 2.0, *)
+    private func configuration(architecture: String? = nil) throws -> DeployerConfiguration {
+        try DeployerConfiguration(arguments: architecture.map { ["--architecture", $0] } ?? [])
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("no manifest falls back to the configured architecture")
+    func noManifestUsesConfigured() throws {
+        let config = try configuration(architecture: "arm64")
+        let resolved = try Deployer.reconcileArchitecture(
+            configuration: config,
+            manifest: nil,
+            functionName: "MyLambda"
+        )
+        #expect(resolved == .arm64)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("no manifest and no explicit architecture uses the host")
+    func noManifestNoExplicitUsesHost() throws {
+        let config = try configuration()
+        let resolved = try Deployer.reconcileArchitecture(
+            configuration: config,
+            manifest: nil,
+            functionName: "MyLambda"
+        )
+        #expect(resolved == .host)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("omitted --architecture adopts the built architecture from the manifest")
+    func omittedAdoptsBuiltArchitecture() throws {
+        let config = try configuration()
+        let manifest = BuildManifest.zip(product: "MyLambda", architecture: .arm64, zipPath: "/o/MyLambda.zip")
+        let resolved = try Deployer.reconcileArchitecture(
+            configuration: config,
+            manifest: manifest,
+            functionName: "MyLambda"
+        )
+        // Regardless of the host, the built architecture wins when the flag is omitted.
+        #expect(resolved == .arm64)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("explicit --architecture matching the built architecture is accepted")
+    func explicitMatchingIsAccepted() throws {
+        let config = try configuration(architecture: "x64")
+        let manifest = BuildManifest.image(
+            product: "MyLambda",
+            architecture: .x64,
+            containerCLI: "docker",
+            imageTag: "swift-lambda/mylambda:latest"
+        )
+        let resolved = try Deployer.reconcileArchitecture(
+            configuration: config,
+            manifest: manifest,
+            functionName: "MyLambda"
+        )
+        #expect(resolved == .x64)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("explicit --architecture disagreeing with the built artifact is a hard error")
+    func explicitMismatchThrows() throws {
+        let config = try configuration(architecture: "x64")
+        let manifest = BuildManifest.zip(product: "MyLambda", architecture: .arm64, zipPath: "/o/MyLambda.zip")
+        #expect(throws: DeployerErrors.self) {
+            _ = try Deployer.reconcileArchitecture(
+                configuration: config,
+                manifest: manifest,
+                functionName: "MyLambda"
+            )
+        }
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("the mismatch error names the function and both architectures")
+    func mismatchErrorIsDescriptive() throws {
+        let config = try configuration(architecture: "x64")
+        let manifest = BuildManifest.zip(product: "MyLambda", architecture: .arm64, zipPath: "/o/MyLambda.zip")
+        do {
+            _ = try Deployer.reconcileArchitecture(
+                configuration: config,
+                manifest: manifest,
+                functionName: "MyLambda"
+            )
+            Issue.record("expected an architecture mismatch error")
+        } catch let error as DeployerErrors {
+            let description = error.description
+            #expect(description.contains("MyLambda"))
+            #expect(description.contains("x64"))
+            #expect(description.contains("arm64"))
+        }
+    }
+}

--- a/Tests/AWSLambdaPluginHelperTests/DeployerConfigurationTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/DeployerConfigurationTests.swift
@@ -72,6 +72,24 @@ struct DeployerConfigurationTests {
         #endif
     }
 
+    // MARK: - Explicit vs default architecture (issue #683)
+
+    @available(LambdaSwift 2.0, *)
+    @Test("explicitArchitecture is set when --architecture is passed")
+    func explicitArchitectureSet() throws {
+        let config = try DeployerConfiguration(arguments: ["--architecture", "arm64"])
+        #expect(config.explicitArchitecture == .arm64)
+        #expect(config.architecture == .arm64)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("explicitArchitecture is nil when --architecture is omitted")
+    func explicitArchitectureNilWhenOmitted() throws {
+        let config = try DeployerConfiguration(arguments: [])
+        #expect(config.explicitArchitecture == nil)
+        #expect(config.architecture == .host)
+    }
+
     // MARK: - Region parsing (Requirement 3.25)
 
     @available(LambdaSwift 2.0, *)

--- a/Tests/AWSLambdaPluginHelperTests/DeployerConfigurationTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/DeployerConfigurationTests.swift
@@ -150,22 +150,33 @@ struct DeployerConfigurationTests {
     // MARK: - Cross-compile (image deploy) parsing
 
     @available(LambdaSwift 2.0, *)
-    @Test("--cross-compile and --cross-compile-tool-path are parsed")
+    @Test("--cross-compile and name-keyed --cross-compile-tool-path are parsed")
     func crossCompileParsing() throws {
         let config = try DeployerConfiguration(arguments: [
             "--cross-compile", "container",
-            "--cross-compile-tool-path", "/usr/local/bin/container",
+            "--cross-compile-tool-path", "docker=/usr/local/bin/docker",
+            "--cross-compile-tool-path", "container=/usr/local/bin/container",
         ])
         #expect(config.crossCompile == "container")
-        #expect(config.crossCompileToolPath?.path().contains("/usr/local/bin/container") == true)
+        #expect(config.crossCompileToolPaths["docker"]?.path().contains("/usr/local/bin/docker") == true)
+        #expect(config.crossCompileToolPaths["container"]?.path().contains("/usr/local/bin/container") == true)
     }
 
     @available(LambdaSwift 2.0, *)
-    @Test("cross-compile options default to nil (resolved from the build manifest)")
+    @Test("a bare --cross-compile-tool-path is treated as docker for backward compatibility")
+    func crossCompileToolPathBareIsDocker() throws {
+        let config = try DeployerConfiguration(arguments: [
+            "--cross-compile-tool-path", "/usr/local/bin/docker",
+        ])
+        #expect(config.crossCompileToolPaths["docker"]?.path().contains("/usr/local/bin/docker") == true)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("cross-compile options default to empty (resolved from the build manifest)")
     func crossCompileDefaultsNil() throws {
         let config = try DeployerConfiguration(arguments: [])
         #expect(config.crossCompile == nil)
-        #expect(config.crossCompileToolPath == nil)
+        #expect(config.crossCompileToolPaths.isEmpty)
     }
 
     // MARK: - With URL flag parsing

--- a/Tests/AWSLambdaPluginHelperTests/DeployerECRTests.swift
+++ b/Tests/AWSLambdaPluginHelperTests/DeployerECRTests.swift
@@ -63,6 +63,100 @@ struct DeployerECRReferenceTests {
     }
 }
 
+@Suite("Deployer container CLI resolution")
+struct DeployerContainerCLIResolutionTests {
+
+    @available(LambdaSwift 2.0, *)
+    private func configuration(
+        crossCompile: String? = nil,
+        toolPaths: [String: String]
+    ) throws
+        -> DeployerConfiguration
+    {
+        var args: [String] = []
+        if let crossCompile {
+            args += ["--cross-compile", crossCompile]
+        }
+        for (name, path) in toolPaths.sorted(by: { $0.key < $1.key }) {
+            args += ["--cross-compile-tool-path", "\(name)=\(path)"]
+        }
+        return try DeployerConfiguration(arguments: args)
+    }
+
+    @available(LambdaSwift 2.0, *)
+    private func manifest(containerCLI: String) -> BuildManifest {
+        BuildManifest.image(
+            product: "MyLambda",
+            architecture: .arm64,
+            containerCLI: containerCLI,
+            imageTag: "swift-lambda/mylambda:latest"
+        )
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("an image built with container selects the container CLI and its path, not docker")
+    func manifestContainerSelectsContainer() throws {
+        // Regression: the manifest's CLI must drive both the argv flavor and the executable, so a
+        // container-built image is never pushed with container-style argv against the docker binary.
+        let config = try configuration(toolPaths: [
+            "docker": "/usr/local/bin/docker",
+            "container": "/usr/local/bin/container",
+        ])
+        let (cli, toolPath) = try Deployer.resolveContainerCLI(
+            configuration: config,
+            manifest: manifest(containerCLI: "container")
+        )
+        #expect(cli is AppleContainerCLI)
+        #expect(toolPath.path().contains("/usr/local/bin/container"))
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("an image built with docker selects the docker CLI and its path")
+    func manifestDockerSelectsDocker() throws {
+        let config = try configuration(toolPaths: [
+            "docker": "/usr/local/bin/docker",
+            "container": "/usr/local/bin/container",
+        ])
+        let (cli, toolPath) = try Deployer.resolveContainerCLI(
+            configuration: config,
+            manifest: manifest(containerCLI: "docker")
+        )
+        #expect(cli is DockerCLI)
+        #expect(toolPath.path().contains("/usr/local/bin/docker"))
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("explicit --cross-compile overrides the manifest CLI")
+    func explicitCrossCompileOverridesManifest() throws {
+        let config = try configuration(
+            crossCompile: "docker",
+            toolPaths: ["docker": "/usr/local/bin/docker", "container": "/usr/local/bin/container"]
+        )
+        let (cli, toolPath) = try Deployer.resolveContainerCLI(
+            configuration: config,
+            manifest: manifest(containerCLI: "container")
+        )
+        #expect(cli is DockerCLI)
+        #expect(toolPath.path().contains("/usr/local/bin/docker"))
+    }
+
+    @available(LambdaSwift 2.0, *)
+    @Test("a descriptive error is thrown when the required CLI path was not resolved")
+    func missingRequiredCLIThrows() throws {
+        // Only docker was resolved, but the image was built with container.
+        let config = try configuration(toolPaths: ["docker": "/usr/local/bin/docker"])
+        #expect {
+            _ = try Deployer.resolveContainerCLI(
+                configuration: config,
+                manifest: manifest(containerCLI: "container")
+            )
+        } throws: { error in
+            guard case DeployerErrors.ecrError(let message) = error else { return false }
+            return message.contains("container")
+        }
+    }
+}
+
 @Suite("Deployer ECR image index unwrap")
 struct DeployerECRImageIndexUnwrapTests {
 


### PR DESCRIPTION
Fixes #683

## Description of changes

`lambda-build` and `lambda-deploy` could independently choose the target architecture, so a user could build an `arm64` binary and deploy a function declaring `x64` (or the reverse). The deploy "succeeded" but the function was broken at invoke time, with no error at build or deploy.

The OCI PR (#687) introduced the `build-manifest.json` hand-off but only wired the architecture into the image deploy path. This PR closes the underlying latent bug for the ZIP path and makes a mismatch impossible to deploy silently.

### `lambda-build`
- Adds `--architecture <x64|arm64>` (default: host).
- The flag actually drives the build: the container is run/pulled/built for that platform (`docker --platform linux/<arch>`, Apple `container --arch <arch>`), so the produced binary matches what the manifest records. The CLI-specific spelling lives in each `ContainerCLI` implementation.
- Both ZIP and OCI backends record the real architecture in `build-manifest.json` (ZIP previously hardcoded `.host`).
- A native (Amazon Linux host) build rejects an explicit cross-architecture request, since it can only target the host and would otherwise record a mismatched architecture.

### `lambda-deploy`
- When `--architecture` is omitted, deploy adopts the architecture recorded in the manifest instead of independently re-defaulting to the host.
- When `--architecture` is passed and disagrees with the built artifact, deploy fails fast with a descriptive error rather than creating a broken function.
- No manifest (legacy `archive` output, or `--input-directory`) falls back to the previous behavior; `--architecture` remains the way to declare the arch there.

### Docs & tests
- Documents the flag and the build→deploy hand-off in the DocC articles.
- Adds unit tests for arg parsing, backend threading, the updated CLI argv, and the deploy-side reconciliation (match / mismatch / omitted / no-manifest).

## New/existing dependencies impact assessment, if applicable

No new dependencies.

## Conventional Commits

fix: enforce architecture consistency between lambda-build and lambda-deploy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

