### PR TITLE
Update CDK infra example dependencies

### DIFF
--- a/Examples/CDK/infra/package-lock.json
+++ b/Examples/CDK/infra/package-lock.json
@@ -8,8 +8,8 @@
       "name": "deploy",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.260.0",
-        "constructs": "^10.4.2"
+        "aws-cdk-lib": "^2.268.0",
+        "constructs": "^10.8.1"
       },
       "bin": {
         "deploy": "bin/deploy.js"
@@ -17,27 +17,27 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "22.13.10",
-        "aws-cdk": "^2.1121.0",
+        "aws-cdk": "^2.1141.0",
         "ts-node": "^10.9.2",
-        "typescript": "~5.8.2"
+        "typescript": "~5.8.3"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.282",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
-      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
-      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.3.tgz",
+      "integrity": "sha512-98We1QWfin9vtuuQtNFhIIAEWb8CreyYTAP0Vn8HqSBoNiFJM9nZgifJeQawT9Wq0NX1HCNFlxCyTccIrK1PSA==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.14.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.14.0.tgz",
-      "integrity": "sha512-JCZCzgp3SuXQVljaKqXnttHzcezEHt9Ag/YipK0XwUFD+Iz2T4jY7gUc3pA25Uq6pzY2n9DvO/nEU++dPXW4Rw==",
+      "version": "54.23.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.23.0.tgz",
+      "integrity": "sha512-6ymdxl2MT34iES1Qot7cWAOzJCoRMrNr/E82/eYAx1inEJXG6iqJOsoa+nTa5Q+Mk+b7Z9xLP3pc2LgNnkFJJw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -188,9 +188,9 @@
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
       "dev": true,
       "license": "MIT"
     },
@@ -337,9 +337,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1133.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
-      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
+      "version": "2.1141.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1141.0.tgz",
+      "integrity": "sha512-RIKueAoFNYUot/VmlUzPUbecxNCtLzJFqpy/O+vTpjrvDn4k2Uiu9Y/QlVlQzaSJw0qqNNY6ldusJVdkX8aBNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.262.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.1.tgz",
-      "integrity": "sha512-B6YP4r6ojUZCDhl+qBu/CrWzcipR8sIgshcqYvgw013sghPXmVkYdJ3yuI9+DKML3YLSjQrHy1nGJs+Nqq7JCg==",
+      "version": "2.268.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.268.0.tgz",
+      "integrity": "sha512-bm0mWG0xxIJtV0vhkmnFy6TFgwqBowvXeRKudhAsjM0TMOEcyFPBbwjUNlAA6S1+AjUwEt5yaMrT0A/P97lUqg==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -369,11 +369,11 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.5.1-beta",
+        "@aws/cloudformation-validate": "1.8.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -408,7 +408,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.5.1-beta",
+      "version": "1.8.0-beta",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -429,14 +429,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.9",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -627,9 +627,9 @@
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.7.1.tgz",
-      "integrity": "sha512-ulK25Sg2Nv1jW+A9VeV7fu9GFN9KdVTNWdXMoapNRwqkQzSdToro/Tttk3Ak5BGI80NRA/d2nSzKnoZ27LizLw==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.1.tgz",
+      "integrity": "sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==",
       "license": "Apache-2.0"
     },
     "node_modules/create-require": {

--- a/Examples/CDK/infra/package.json
+++ b/Examples/CDK/infra/package.json
@@ -12,12 +12,12 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "22.13.10",
-    "aws-cdk": "^2.1121.0",
+    "aws-cdk": "^2.1141.0",
     "ts-node": "^10.9.2",
-    "typescript": "~5.8.2"
+    "typescript": "~5.8.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.260.0",
-    "constructs": "^10.4.2"
+    "aws-cdk-lib": "^2.268.0",
+    "constructs": "^10.8.1"
   }
 }

--- a/Examples/Streaming+Codable/Sources/LambdaStreaming+Codable.swift
+++ b/Examples/Streaming+Codable/Sources/LambdaStreaming+Codable.swift
@@ -48,11 +48,11 @@ public protocol StreamingLambdaHandlerWithEvent: _Lambda_SendableMetatype {
     ///   - If ``LambdaResponseStreamWriter/finish()`` has already been called before the error is thrown, the
     ///     error will be logged.
     nonisolated(nonsending)
-    mutating func handle(
-        _ event: Event,
-        responseWriter: some LambdaResponseStreamWriter,
-        context: LambdaContext
-    ) async throws
+        mutating func handle(
+            _ event: Event,
+            responseWriter: some LambdaResponseStreamWriter,
+            context: LambdaContext
+        ) async throws
 }
 
 /// Adapts a ``StreamingLambdaHandlerWithEvent`` to work as a ``StreamingLambdaHandler``
@@ -131,11 +131,12 @@ public struct StreamingFromEventClosureHandler<Event: Decodable>: StreamingLambd
     ///   - responseWriter: The response writer for streaming output.
     ///   - context: The Lambda context.
     nonisolated(nonsending)
-    public func handle(
-        _ event: Event,
-        responseWriter: some LambdaResponseStreamWriter,
-        context: LambdaContext
-    ) async throws {
+        public func handle(
+            _ event: Event,
+            responseWriter: some LambdaResponseStreamWriter,
+            context: LambdaContext
+        ) async throws
+    {
         try await self.body(event, responseWriter, context)
     }
 }
@@ -162,7 +163,9 @@ extension LambdaRuntime {
     public convenience init<Event: Decodable>(
         decoder: JSONDecoder = JSONDecoder(),
         logger: Logger = Logger.current,
-        streamingBody: nonisolated(nonsending) @Sendable @escaping (Event, LambdaResponseStreamWriter, LambdaContext) async throws -> Void
+        streamingBody:
+            nonisolated(nonsending) @Sendable @escaping (Event, LambdaResponseStreamWriter, LambdaContext) async throws
+            -> Void
     )
     where
         Handler == StreamingLambdaCodableAdapter<


### PR DESCRIPTION
## Summary
Minor dependency version bumps for the CDK infrastructure example (`Examples/CDK/infra`), pulled in via `npm update`.

Updated ranges in `package.json` to match the resolved versions in `package-lock.json`:

| Package | Old | New |
| --- | --- | --- |
| `aws-cdk` (dev) | `^2.1121.0` | `^2.1141.0` |
| `typescript` (dev) | `~5.8.2` | `~5.8.3` |
| `aws-cdk-lib` | `^2.260.0` | `^2.268.0` |
| `constructs` | `^10.4.2` | `^10.8.1` |

## Testing
- `npm install --package-lock-only` reports the lock file is up to date with no vulnerabilities.

## Notes
Scoped to the CDK example only; no runtime library changes.